### PR TITLE
cjk-gs-integrate.pl (encode_list): added 2004-{H,V} for Japan

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -34,6 +34,8 @@ if (win32()) {
 
 my %encode_list = (
   Japan => [ qw/
+    2004-H
+    2004-V
     78-EUC-H
     78-EUC-V
     78-H


### PR DESCRIPTION
最近のTeX Liveは、cmap 2004-H, 2004-V を持っていますので、これらのcmapたちを %encode_list に追加しませんか？
