### PR TITLE
Assume relative path of gs-resource

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1059,6 +1059,9 @@ sub find_gs_resource {
       # /path/to/share/ghostscript/$(gs --version)/Resource
       chomp( $foundres = `which gs` );
       $foundres =~ s/\/bin\/gs/\/share\/ghostscript\/@gsver\/Resource/;
+      if ( ! -d $foundres ) {
+        $foundres = '';
+      }
       if (!$foundres) {
         print_error("Found gs but no resource???\n");
       }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1046,25 +1046,22 @@ sub read_font_database {
 }
 
 sub find_gs_resource {
-  # we assume that gs is in the path
-  # on Windows we probably have to try something else
-  chomp( my @ret = `gs --help 2>$nul` );
   my $foundres = '';
-  if ($?) {
-    print_error("Cannot find gs ...\n");
-  } else {
-    # try to find resource line
-    for (@ret) {
-      if (m!Resource/Font!) {
-        $foundres = $_;
-        # extract the first substring of non-space chars
-        # up to Resource/Font and drop the /Font part
-        $foundres =~ s!^.*\s(\S*Resource)/Font.*$!$1!;
-        last;
+  if (!win32()) {
+    # we assume that gs is in the path
+    # on Windows we probably have to try something else
+    chomp( my @gsver = `gs --version 2>$nul` );
+    if ($?) {
+      print_error("Cannot find gs ...\n");
+    } else {
+      # assume the relative path
+      # when /path/to/bin/gs is found, then there should be
+      # /path/to/share/ghostscript/$(gs --version)/Resource
+      chomp( $foundres = `which gs` );
+      $foundres =~ s/\/bin\/gs/\/share\/ghostscript\/@gsver\/Resource/;
+      if (!$foundres) {
+        print_error("Found gs but no resource???\n");
       }
-    }
-    if (!$foundres) {
-      print_error("Found gs but no resource???\n");
     }
   }
   return $foundres;


### PR DESCRIPTION
現在の cjk-gs-integrate は、Resource を探すために
1. `gs --help` を実行
2. `/path/to/Resource/Font :` という line を探して `/Font` を drop

という方法を使っています。しかし、この方法では、pre-built な ghostscript distribution を arbitary path にインストールしたとき、実際とは違う directory に snippets がアウトプットされてしまいます。たとえば、奥村さんの美文書の gs installer for Mac は

```
$ gs --help
    (snip)
    /usr/local/share/ghostscript/9.xx/Resource/Init
```

と表示しますが、実際の install path は

```
$ which gs
/Applications/TeXLive/Library/mactexaddons/bin/gs
```

となっていて、Resource は
- `/Applications/TeXLive/Library/mactexaddons/share/ghostscript/9.xx/Resource`

にあります。`gs --help` の場所と、実際の Resource の場所が異なる場合にも対応できる、よりよい方法を提案します。

最近の gs は、Makefile.in のなかで
- /path/to/bin/gs --> /path/to/share/ghostscript/9.20/Resource

という relative path があります。これを使うことができます。

（以前 @doraTeX さんと http://d.hatena.ne.jp/acetaminophen/20151020/1445358449 の comment 欄で議論したのを、コードに書いてみました。）
