### PR TITLE
Extend database format to distinguish TTF/TTC/OTC

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -999,7 +999,7 @@ sub determine_nonotf_link_name {
         }
       } elsif ($fontdb{$k}{'files'}{$f}{'type'} eq 'OTC') {
         my $p = $fontdb{$k}{'files'}{$f}{'priority'};
-        if ($p < $mpttc) {
+        if ($p < $mpotc) {
           $otcname = $f;
           $otcname =~ s/^(.*)\(\d*\)$/$1/;
           $mpotc = $p;

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -333,7 +333,7 @@ sub main {
         my $fn = ($opt_listallaliases ? "-" : $fontdb{$t}{'target'} );
         # should always be the same ;-)
         $cl = $fontdb{$t}{'class'};
-        if (!$opt_listallaliases && $fontdb{$t}{'type'} eq 'TTC' && $fontdb{$t}{'subfont'} > 0) {
+        if (!$opt_listallaliases && ($fontdb{$t}{'type'} eq 'TTC' or $fontdb{$t}{'type'} eq 'OTC') && $fontdb{$t}{'subfont'} > 0) {
           $fn .= "($fontdb{$t}{'subfont'})";
         }
         if ($opt_machine) {
@@ -930,7 +930,13 @@ sub compute_aliases {
           print_warning("  current $p $fontdb{$k}{'provides'}{$p} $aliases{$p}{$fontdb{$k}{'provides'}{$p}}\n");
           print_warning("  ignored $p $fontdb{$k}{'provides'}{$p} $k\n");
         } else {
-          $aliases{$p}{$fontdb{$k}{'provides'}{$p}} = $k;
+          # if OTC font is caught, then skip it as Ghostscript doesn't support it (2016/12/12)
+          if ($fontdb{$k}{'type'} eq 'OTC') {
+            print_warning("Currently Ghostscript does not support OTC font,\n");
+            print_warning("not adding $fontdb{$k}{'otcname'} to aliases\n");
+          } else {
+            $aliases{$p}{$fontdb{$k}{'provides'}{$p}} = $k;
+          }
         }
       }
     }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2279,13 +2279,13 @@ OTCname(28): HiraginoSansGB-W6.ttc(0)
 
 Name: HiraginoSansCNS-W3
 Class: CNS
-Filename(30): Hiragino Sans CNS.ttc(0)
-Filename(28): HiraginoSansCNS.ttc(0)
+OTCname(30): Hiragino Sans CNS.ttc(0)
+OTCname(28): HiraginoSansCNS.ttc(0)
 
 Name: HiraginoSansCNS-W6
 Class: CNS
-Filename(30): Hiragino Sans CNS.ttc(1)
-Filename(28): HiraginoSansCNS.ttc(1)
+OTCname(30): Hiragino Sans CNS.ttc(1)
+OTCname(28): HiraginoSansCNS.ttc(1)
 
 # DynaComware (OS X)
 
@@ -2517,91 +2517,91 @@ TTCname(10): Kaiti.ttc(6)
 
 Name: STBaoliSC-Regular
 Class: GB
-Filename: Baoli.ttc(0)
+TTCname: Baoli.ttc(0)
 
 Name: STBaoliTC-Regular
 Class: CNS
-Filename: Baoli.ttc(1)
+TTCname: Baoli.ttc(1)
 
 Name: STLibianSC-Regular
 Class: GB
-Filename: Libian.ttc(0)
+TTCname: Libian.ttc(0)
 
 Name: STLibianTC-Regular
 Class: CNS
-Filename: Libian.ttc(1)
+TTCname: Libian.ttc(1)
 
 Name: STXingkaiSC-Bold
 Class: GB
-Filename: Xingkai.ttc(0)
+TTCname: Xingkai.ttc(0)
 
 Name: STXingkaiTC-Bold
 Class: CNS
-Filename: Xingkai.ttc(1)
+TTCname: Xingkai.ttc(1)
 
 Name: STXingkaiSC-Light
 Class: GB
-Filename: Xingkai.ttc(2)
+TTCname: Xingkai.ttc(2)
 
 Name: STXingkaiTC-Light
 Class: CNS
-Filename: Xingkai.ttc(3)
+TTCname: Xingkai.ttc(3)
 
 Name: STYuanti-SC-Regular
 Class: GB
-Filename: Yuanti.ttc(0)
+TTCname: Yuanti.ttc(0)
 
 Name: STYuanti-TC-Regular
 Class: CNS
-Filename: Yuanti.ttc(1)
+TTCname: Yuanti.ttc(1)
 
 Name: STYuanti-SC-Bold
 Class: GB
-Filename: Yuanti.ttc(2)
+TTCname: Yuanti.ttc(2)
 
 Name: STYuanti-TC-Bold
 Class: CNS
-Filename: Yuanti.ttc(3)
+TTCname: Yuanti.ttc(3)
 
 Name: STYuanti-SC-Light
 Class: GB
-Filename: Yuanti.ttc(4)
+TTCname: Yuanti.ttc(4)
 
 Name: STYuanti-TC-Light
 Class: CNS
-Filename: Yuanti.ttc(5)
+TTCname: Yuanti.ttc(5)
 
 # Beijing Founder Electronics (OS X)
 
 # Lantinghei SC Demibold
 Name: FZLTZHK--GBK1-0
 Class: GB
-Filename: Lantinghei.ttc(0)
+TTCname: Lantinghei.ttc(0)
 
 # Lantinghei SC Extralight
 Name: FZLTXHK--GBK1-0
 Class: GB
-Filename: Lantinghei.ttc(1)
+TTCname: Lantinghei.ttc(1)
 
 # Lantinghei SC Heavy
 Name: FZLTTHK--GBK1-0
 Class: GB
-Filename: Lantinghei.ttc(2)
+TTCname: Lantinghei.ttc(2)
 
 # Lantinghei TC Demibold
 Name: FZLTZHB--B51-0
 Class: CNS
-Filename: Lantinghei.ttc(3)
+TTCname: Lantinghei.ttc(3)
 
 # Lantinghei TC Extralight
 Name: FZLTXHB--B51-0
 Class: CNS
-Filename: Lantinghei.ttc(4)
+TTCname: Lantinghei.ttc(4)
 
 # Lantinghei TC Heavy
 Name: FZLTTHB--B51-0
 Class: CNS
-Filename: Lantinghei.ttc(5)
+TTCname: Lantinghei.ttc(5)
 
 # Arphic Font Design Team (OS X)
 
@@ -2641,35 +2641,35 @@ OTFname: WawaSC-Regular.otf
 
 Name: HannotateSC-W5
 Class: GB
-Filename: Hannotate.ttc(0)
+OTCname: Hannotate.ttc(0)
 
 Name: HannotateTC-W5
 Class: CNS
-Filename: Hannotate.ttc(1)
+OTCname: Hannotate.ttc(1)
 
 Name: HannotateSC-W7
 Class: GB
-Filename: Hannotate.ttc(2)
+OTCname: Hannotate.ttc(2)
 
 Name: HannotateTC-W7
 Class: CNS
-Filename: Hannotate.ttc(3)
+OTCname: Hannotate.ttc(3)
 
 Name: HanziPenSC-W3
 Class: GB
-Filename: Hanzipen.ttc(0)
+OTCname: Hanzipen.ttc(0)
 
 Name: HanziPenTC-W3
 Class: CNS
-Filename: Hanzipen.ttc(1)
+OTCname: Hanzipen.ttc(1)
 
 Name: HanziPenSC-W5
 Class: GB
-Filename: Hanzipen.ttc(2)
+OTCname: Hanzipen.ttc(2)
 
 Name: HanziPenTC-W5
 Class: CNS
-Filename: Hanzipen.ttc(3)
+OTCname: Hanzipen.ttc(3)
 
 # Adobe chinese fonts
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -333,7 +333,7 @@ sub main {
         my $fn = ($opt_listallaliases ? "-" : $fontdb{$t}{'target'} );
         # should always be the same ;-)
         $cl = $fontdb{$t}{'class'};
-        if (!$opt_listallaliases && ($fontdb{$t}{'type'} eq 'TTC' or $fontdb{$t}{'type'} eq 'OTC') && $fontdb{$t}{'subfont'} > 0) {
+        if (!$opt_listallaliases && ($fontdb{$t}{'type'} eq 'TTC' or $fontdb{$t}{'type'} eq 'OTC')) {
           $fn .= "($fontdb{$t}{'subfont'})";
         }
         if ($opt_machine) {
@@ -742,7 +742,7 @@ sub info_found_fonts {
       print "Type:  $fontdb{$k}{'type'}\n";
       print "Class: $fontdb{$k}{'class'}\n";
       my $fn = $fontdb{$k}{'target'};
-      if (($fontdb{$k}{'type'} eq 'TTC' or $fontdb{$k}{'type'} eq 'OTC') && $fontdb{$k}{'subfont'} > 0) {
+      if ($fontdb{$k}{'type'} eq 'TTC' or $fontdb{$k}{'type'} eq 'OTC') {
         $fn .= "($fontdb{$k}{'subfont'})";
       }
       print "File:  $fn\n";

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -933,7 +933,7 @@ sub compute_aliases {
           # if OTC font is caught, then skip it as Ghostscript doesn't support it (2016/12/12)
           if ($fontdb{$k}{'type'} eq 'OTC') {
             print_warning("Currently Ghostscript does not support OTC font,\n");
-            print_warning("not adding $fontdb{$k}{'otcname'} to aliases\n");
+            print_warning("not adding $fontdb{$k}{'otcname'} to alias candidates\n");
           } else {
             $aliases{$p}{$fontdb{$k}{'provides'}{$p}} = $k;
           }
@@ -1104,17 +1104,23 @@ sub read_font_database {
       $fontfiles{$fn}{'type'} = 'TTC';
       next;
     }
-    # only for backward compatibility (TODO: separate otf/otc, ttf/ttc)
+    # only for backward compatibility; guess type from the file extension
     if ($l =~ m/^Filename(\((\d+)\))?:\s*(.*)$/) {
       my $fn = $3;
       $fontfiles{$fn}{'priority'} = ($2 ? $2 : 10);
       print_ddebug("filename: $fn\n");
-      if ($fn =~ m/\.ot[fc](\(\d+\))?$/i) {
+      if ($fn =~ m/\.otf$/i) {
         print_ddebug("type: otf\n");
         $fontfiles{$fn}{'type'} = 'OTF';
-      } elsif ($fn =~ m/\.tt[fc](\(\d+\))?$/i) {
+      } elsif ($fn =~ m/\.otc(\(\d+\))?$/i) {
+        print_ddebug("type: otc\n");
+        $fontfiles{$fn}{'type'} = 'OTC';
+      } elsif ($fn =~ m/\.ttf$/i) {
         print_ddebug("type: ttf\n");
         $fontfiles{$fn}{'type'} = 'TTF';
+      } elsif ($fn =~ m/\.ttc(\(\d+\))?$/i) {
+        print_ddebug("type: ttc\n");
+        $fontfiles{$fn}{'type'} = 'TTC';
       } else {
         print_warning("cannot determine font type of $fn at line $lineno, skipping!\n");
         delete $fontfiles{$fn};

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -588,14 +588,14 @@ sub do_nonotf_fonts {
            "cannot link fonts to it!")
     if $opt_texmflink;
   for my $k (keys %fontdb) {
-    if ($fontdb{$k}{'available'} && ($fontdb{$k}{'type'} eq 'TTF')) {
+    if ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'TTF') {
       generate_font_snippet($fontdest,
         $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
       $outp .= generate_cidfmap_entry($k, $fontdb{$k}{'class'}, $fontdb{$k}{'ttfname'}, $fontdb{$k}{'subfont'});
       link_font($fontdb{$k}{'target'}, $cidfsubst, $fontdb{$k}{'ttfname'});
       link_font($fontdb{$k}{'target'}, "$opt_texmflink/$ttf_pathpart", $fontdb{$k}{'ttfname'})
         if $opt_texmflink;
-    } elsif ($fontdb{$k}{'available'} && ($fontdb{$k}{'type'} eq 'TTC')) {
+    } elsif ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'TTC') {
       generate_font_snippet($fontdest,
         $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
       $outp .= generate_cidfmap_entry($k, $fontdb{$k}{'class'}, $fontdb{$k}{'ttcname'}, $fontdb{$k}{'subfont'});
@@ -707,7 +707,7 @@ sub do_aliases {
 sub generate_cidfmap_entry {
   my ($n, $c, $f, $sf) = @_;
   return "" if $opt_remove;
-  # $f is already the link target name 'ttname'
+  # $f is already the link target name 'ttfname' (or 'ttcname' or 'otcname')
   # as determined by minimal priority number
   # extract subfont
   my $s = "/$n << /FileType /TrueType 
@@ -742,12 +742,16 @@ sub info_found_fonts {
       print "Type:  $fontdb{$k}{'type'}\n";
       print "Class: $fontdb{$k}{'class'}\n";
       my $fn = $fontdb{$k}{'target'};
-      if ($fontdb{$k}{'type'} eq 'TTC' && $fontdb{$k}{'subfont'} > 0) {
+      if (($fontdb{$k}{'type'} eq 'TTC' or $fontdb{$k}{'type'} eq 'OTC') && $fontdb{$k}{'subfont'} > 0) {
         $fn .= "($fontdb{$k}{'subfont'})";
       }
       print "File:  $fn\n";
-      if ($fontdb{$k}{'type'} eq 'TTF' or $fontdb{$k}{'type'} eq 'TTC') {
-        print "Link:  $fontdb{$k}{'ttname'}\n";
+      if ($fontdb{$k}{'type'} eq 'TTF') {
+        print "Link:  $fontdb{$k}{'ttfname'}\n";
+      } elsif ($fontdb{$k}{'type'} eq 'TTC') {
+        print "Link:  $fontdb{$k}{'ttcname'}\n";
+      } elsif ($fontdb{$k}{'type'} eq 'OTC') {
+        print "Link:  $fontdb{$k}{'otcname'}\n";
       }
       my @ks = sort { $fontdb{$k}{'files'}{$a}{'priority'}
                       <=>
@@ -900,7 +904,7 @@ sub check_for_files {
       if ($mf =~ m/^(.*)\((\d*)\)$/) { $sf = $2; }
       $fontdb{$k}{'target'} = $fontdb{$k}{'files'}{$mf}{'target'};
       $fontdb{$k}{'type'} = $fontdb{$k}{'files'}{$mf}{'type'};
-      $fontdb{$k}{'subfont'} = $sf if ($fontdb{$k}{'type'} eq 'TTF' or $fontdb{$k}{'type'} eq 'TTC');
+      $fontdb{$k}{'subfont'} = $sf if ($fontdb{$k}{'type'} eq 'TTF' or $fontdb{$k}{'type'} eq 'TTC' or $fontdb{$k}{'type'} eq 'OTC');
     }
     # not needed anymore
     # delete $fontdb{$k}{'files'};

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2605,11 +2605,13 @@ TTCname: Lantinghei.ttc(5)
 
 # Arphic Font Design Team (OS X)
 
-Name: Weibei-SC-Bold
+Name: WeibeiSC-Bold
+PSName: Weibei-SC-Bold
 Class: GB
 OTFname: WeibeiSC-Bold.otf
 
-Name: Weibei-TC-Bold
+Name: WeibeiTC-Bold
+PSName: Weibei-TC-Bold
 Class: CNS
 OTFname: WeibeiTC-Bold.otf
 
@@ -2625,17 +2627,20 @@ OTFname: YuppyTC-Regular.otf
 
 # Monotype Hong Kong (OS X)
 
-Name: MLingWaiMedium-SC
+Name: LingWaiSC-Medium
+PSName: MLingWaiMedium-SC
 Class: GB
 OTFname: LingWaiSC-Medium.otf
 
-Name: MLingWaiMedium-TC
+Name: LingWaiTC-Medium
+PSName: MLingWaiMedium-TC
 Class: CNS
 OTFname: LingWaiTC-Medium.otf
 
 # DynaComware Taiwan (OS X)
 
-Name: DFWaWaSC-W5
+Name: WawaSC-Regular
+PSName: DFWaWaSC-W5
 Class: GB
 OTFname: WawaSC-Regular.otf
 


### PR DESCRIPTION
cjk-gs-integrate の database を parse するコードを、全体的に書き直しました。

今までのコードには、以下の問題がありました。

----

[1] OTC と TTC が区別できない。たとえば、database が以下の内容だとします。

~~~~
Name: HiraMinProN-W3
Class: Japan
Provides(30): Ryumin-Light
Provides(30): RyuminPro-Light
Filename(20): ヒラギノ明朝 ProN W3.otf
Filename(19): ヒラギノ明朝 ProN W3.otf
Filename(10): HiraMinProN-W3.otf
Filename(30): ヒラギノ明朝 ProN W3.ttc(0)
Filename(29): ヒラギノ明朝 ProN W3.ttc(0)
Filename(28): HiraginoSerif-W3.ttc(0)

Name: IPAexMincho
Class: Japan
Provides(100): Ryumin-Light
Provides(100): RyuminPro-Light
Provides(100): FutoMinA101-Bold
Provides(100): FutoMinA101Pro-Bold
Filename(20): ipaexm.ttf
~~~~

スクリプトを OS X Yosemite で実行すると、コンピュータから「ヒラギノ明朝 ProN W3.otf」と「ipaexm.ttf」が見つかります。この場合、Ryumin-Light の alias は「HiraMinProN-W3」になるので gs は ok です。

しかし、スクリプトを OS X El Capitan で実行すると、コンピュータから「ヒラギノ明朝 ProN W3.ttc」と「ipaexm.ttf」が見つかります。この場合、Ryumin-Light の alias は「HiraginoSerif-W3.ttc」になりますが、gs は OpenType Collection (OTC) を使えないのでよくないです。だから、OTC の場合は alias を決めるときに無視するほうがよいです。

[2] symlink が .ttc → .ttf に張られる場合がある。たとえば、database が下のようになっているとき

~~~~
Name: YuGothic-Regular
Class: Japan
Provides(60): GothicBBB-Medium
Provides(60): GothicBBBPro-Medium
Filename(20): yugothic.ttf
Filename(30): YuGothR.ttc(0)
~~~~

コンピュータに YuGothR.ttc だけが見つかると、symlink は yugothic.ttf => YuGothR.ttc になります。このような TTF → TTC の symlink ができるのはよくないです。

-----

この 2 つの問題を解決するために、スクリプトを書き直しました。

[1] database の `Filename:` entry を廃止（backward compatibility のため、database を parse する関数は `Filename:` entry を解釈できるように残す）。新しく `OTFname:` `OTCname:` `TTCname:` `TTFname:` のどれかを使う。

[2] priority number で symlink を決めるとき、TTF / TTC / OTC の名前を別々に save する。複数見つかったら、その中でいちばん小さな priority number の type で決められた symlink の名前を使う。

[3] OTC フォントの場合は、gs の Resource に何も作らない（単にスキップする）。alias を決めるときもスキップする。