### PR TITLE
Experimental Win32 support

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -753,6 +753,60 @@ sub generate_cidfmap_entry {
   return $s;
 }
 
+sub maybe_symlink {
+  my ($realname, $targetname) = @_;
+  if (win32()) {
+#    open(FOO, ">$targetname") || 
+#      die("cannot open $targetname for writing: $!");
+#    print FOO "$realname";
+#    close(FOO);
+    open(FOO, ">>$winbatch") || 
+      die("cannot open $winbatch for writing: $!");
+    $realname =~ s!/!\\!g;
+    $targetname =~ s!/!\\!g;
+    print FOO "mklink $targetname $realname\n";
+    close(FOO);
+  } else {
+    symlink ($realname, $targetname);
+  }
+}
+
+# initialize batch file (windows only)
+sub init_winbatch {
+  open(FOO, ">$winbatch") || 
+    die("cannot open $winbatch for writing: $!");
+  print FOO "\@echo off\n";
+  close(FOO);
+}
+
+# complete batch file (windows only)
+sub complete_winbatch {
+  open(FOO, ">>$winbatch") || 
+    die("cannot open $winbatch for writing: $!");
+  print FOO "\@echo symlink generated\n";
+  print FOO "\@pause 1\n";
+  close(FOO);
+}
+
+# initialize psnames-for-otfps
+sub init_akotfps_datafile {
+  make_dir("$opt_texmflink/$akotfps_pathpart",
+         "cannot create $akotfps_datafilename in it!")
+  if $opt_texmflink;
+  open(FOO, ">$opt_texmflink/$akotfps_pathpart/$akotfps_datafilename") || 
+    die("cannot open $opt_texmflink/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
+  print FOO "% psnames-for-otf
+%
+% PostSctipt names for OpenType fonts
+%
+% This file is used by a program ps2otfps
+% in order to add needed information to a ps file
+% created by the dvips
+%
+";
+  close(FOO);
+}
+
 #
 # dump found files
 sub info_found_fonts {
@@ -1440,60 +1494,6 @@ sub print_for_out {
       print "$indent$_\n";
     }
   }
-}
-
-sub maybe_symlink {
-  my ($realname, $targetname) = @_;
-  if (win32()) {
-#    open(FOO, ">$targetname") || 
-#      die("cannot open $targetname for writing: $!");
-#    print FOO "$realname";
-#    close(FOO);
-    open(FOO, ">>$winbatch") || 
-      die("cannot open $winbatch for writing: $!");
-    $realname =~ s!/!\\!g;
-    $targetname =~ s!/!\\!g;
-    print FOO "mklink $targetname $realname\n";
-    close(FOO);
-  } else {
-    symlink ($realname, $targetname);
-  }
-}
-
-# initialize batch file (windows only)
-sub init_winbatch {
-  open(FOO, ">$winbatch") || 
-    die("cannot open $winbatch for writing: $!");
-  print FOO "\@echo off\n";
-  close(FOO);
-}
-
-# complete batch file (windows only)
-sub complete_winbatch {
-  open(FOO, ">>$winbatch") || 
-    die("cannot open $winbatch for writing: $!");
-  print FOO "\@echo symlink generated\n";
-  print FOO "\@pause 1\n";
-  close(FOO);
-}
-
-# initialize psnames-for-otfps
-sub init_akotfps_datafile {
-  make_dir("$opt_texmflink/$akotfps_pathpart",
-         "cannot create $akotfps_datafilename in it!")
-  if $opt_texmflink;
-  open(FOO, ">$opt_texmflink/$akotfps_pathpart/$akotfps_datafilename") || 
-    die("cannot open $opt_texmflink/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
-  print FOO "% psnames-for-otf
-%
-% PostSctipt names for OpenType fonts
-%
-% This file is used by a program ps2otfps
-% in order to add needed information to a ps file
-% created by the dvips
-%
-";
-  close(FOO);
 }
 
 # info/warning can be suppressed


### PR DESCRIPTION
私はときどき Mac で開発していますが、メインは Win32 を使っているので、cjk-gs-integrate が Win32 でも動けばいいと思っています。というわけで少し書いてみました。ただし、TeX Live win32 の tlgs はまだサポートしていません。standalone の gswin32c の場合で動作するようにしています。

- Win32 では perl の symlink function がサポートされていません。そこで、代わりに makefontlinks.bat を作るようにしました。cjk-gs-integrate を実行したあとで、この batch file を cmd.exe で実行すると symlink が作れます。
- 角藤さんの ps2otfps というプログラムがあって、これは dvips で作った PS を自動で編集して、Resource/Font にたくさん snippet を作らなくても CJK フォントを使えるようにします。この ps2otfps が使う configuration file である psnames-for-otf も同時に作ります。

まだ不完全ですから、merge はしないでください。感想をもらえると助かります。