### PR TITLE
Experimental Win32 support (again)

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -533,7 +533,7 @@ sub add_akotfps_data {
   my ($fn) = @_;
   return if $dry_run;
   if (! $opt_remove) {
-    $akotfps_datacontent = "$akotfps_datacontent$fn\n";
+    $akotfps_datacontent .= "$fn\n";
   }
 }
 
@@ -792,7 +792,7 @@ sub maybe_symlink {
     # close(FOO);
     $realname =~ s!/!\\!g;
     $targetname =~ s!/!\\!g;
-    $winbatch_content = "$winbatch_content mklink $targetname $realname\n";
+    $winbatch_content .= "mklink $targetname $realname\n";
   } else {
     symlink ($realname, $targetname);
   }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -406,18 +406,20 @@ sub main {
       die ("Cannot create directory $opt_output: $!");
   }
   print_info("output is going to $opt_output\n");
+
+  init_akotfps_datafile() if ($opt_akotfps);
   if (!$opt_only_aliases) {
     init_winbatch() if (win32());
-    init_akotfps_datafile() if ($opt_akotfps);
     print_info(($opt_remove ? "removing" : "generating") . " font snippets and link CID fonts ...\n");
     do_otf_fonts();
     print_info(($opt_remove ? "removing" : "generating") . " font snippets, links, and cidfmap.local for TTF fonts ...\n");
     do_nonotf_fonts();
     complete_winbatch() if (win32());
-    complete_akotfps_datafile() if ($opt_akotfps);
   }
   print_info(($opt_remove ? "removing" : "generating") . " font aliases ...\n");
   do_aliases();
+  complete_akotfps_datafile() if ($opt_akotfps);
+
   print_info("finished\n");
 }
 
@@ -723,8 +725,13 @@ sub do_aliases {
       $target = $aliases{$al}{$first};
       $class  = $fontdb{$target}{'class'};
     }
-    # we also need to create font snippets in Font for the aliases!
-    generate_font_snippet($fontdest, $al, $class, $target);
+    # we also need to create font snippets in Font (or add configuration)
+    # for the aliases!
+    if ($opt_akotfps) {
+      add_akotfps_data($al);
+    } else {
+      generate_font_snippet($fontdest, $al, $class, $target);
+    }
     if ($class eq 'Japan') {
       push @jal, "/$al /$target ;";
     } elsif ($class eq 'Korea') {

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -3278,6 +3278,28 @@ Name: HanziPenTC-W5
 Class: CNS
 OTCname: Hanzipen.ttc(3)
 
+# Shanghai Ikarus Ltd./URW Software & Type GmbH
+
+Name: SIL-Hei-Med-Jian
+Class: GB
+TTFname: Hei.ttf
+
+Name: SIL-Kai-Reg-Jian
+Class: GB
+TTFname: Kai.ttf
+
+# Apple
+
+Name: LiSungLight
+Class: CNS
+TTFname(20): Apple LiSung Light.ttf
+TTFname(10): LiSungLight.ttf
+
+Name: LiGothicMed
+Class: CNS
+TTFname(20): Apple LiGothic Medium.ttf
+TTFname(10): LiGothicMed.ttf
+
 # Adobe chinese fonts
 
 # simplified chinese
@@ -3741,6 +3763,18 @@ Name: AppleSDGothicNeo-Heavy
 Class: Korea
 OTFname: AppleSDGothicNeo-Heavy.otf
 
+Name: JCsmPC
+Class: Korea
+TTFname: PCmyoungjo.ttf
+
+Name: JCfg
+Class: Korea
+TTFname: Pilgiche.ttf
+
+Name: JCkg
+Class: Korea
+TTFname: Gungseouche.ttf
+
 # Adobe korean fonts
 
 Name: AdobeMyungjoStd-Medium
@@ -3911,7 +3945,8 @@ TTCname(20): mingliu.ttc(1)
 
 Name: DFKaiShu-SB-Estd-BF
 Class: CNS
-TTFname: kaiu.ttf
+TTFname(50): BiauKai.ttf
+TTFname(20): kaiu.ttf
 
 Name: MicrosoftJhengHeiRegular
 Class: CNS

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -791,6 +791,13 @@ sub generate_cidfmap_entry {
 sub maybe_symlink {
   my ($realname, $targetname) = @_;
   if (win32()) {
+    # TODO NP
+    # why don't do we
+    # if (! -r $targetname) {
+    #   $ret = `mklink "$targetname" "$realname"`;
+    # }
+    # here instead of generating a batch file?
+    #
     # open(FOO, ">$targetname") || 
     #   die("cannot open $targetname for writing: $!");
     # print FOO "$realname";

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2133,6 +2133,9 @@ OTCname(30): YuMincho.ttc(5)
 #   YuGothic.ttf
 #   YuGothic-Bold.ttf
 # are bundled with VS2013 or later versions.
+#   YuGoth{B,L,M,R}.ttf
+#   yumin.ttf, yumin{db,l}.ttf
+# are bundled with Office for Mac 2016.
 # Also, symlink names should be consistent with ptex-fontmaps!
 
 Name: YuMincho-Regular
@@ -2142,12 +2145,12 @@ Provides(90): RyuminPro-Light
 Provides(90): HiraMinProN-W3
 Provides(90): HiraMinPro-W3
 TTFname(20): yumin.ttf
-#TTFname(21): YuMincho-Regular.ttf
+#TTFname(50): YuMincho-Regular.ttf
 
 Name: YuMincho-Light
 Class: Japan
 TTFname(20): yuminl.ttf
-#TTFname(21): YuMincho-Light.ttf
+#TTFname(50): YuMincho-Light.ttf
 
 Name: YuMincho-DemiBold
 Class: Japan
@@ -2156,7 +2159,7 @@ Provides(90): FutoMinA101Pro-Bold
 Provides(90): HiraMinProN-W6
 Provides(90): HiraMinPro-W6
 TTFname(20): yumindb.ttf
-#TTFname(21): YuMincho-DemiBold.ttf
+#TTFname(50): YuMincho-DemiBold.ttf
 
 Name: YuGothic-Regular
 Class: Japan
@@ -2165,18 +2168,21 @@ Provides(90): GothicBBBPro-Medium
 Provides(90): HiraKakuProN-W3
 Provides(90): HiraKakuPro-W3
 TTFname(20): yugothic.ttf
-#TTFname(21): YuGothic-Regular.ttf
 TTCname(30): YuGothR.ttc(0)
+TTFname(40): YuGothR.ttf
+#TTFname(50): YuGothic-Regular.ttf
 
 Name: YuGothic-Medium
 Class: Japan
 TTCname(30): YuGothM.ttc(0)
+TTFname(40): YuGothM.ttf
 
 Name: YuGothic-Light
 Class: Japan
 TTFname(20): yugothil.ttf
-#TTFname(21): YuGothic-Light.ttf
 TTCname(30): YuGothL.ttc(0)
+TTFname(40): YuGothL.ttf
+#TTFname(50): YuGothic-Light.ttf
 
 Name: YuGothic-Bold
 Class: Japan
@@ -2193,8 +2199,9 @@ Provides(90): MidashiGoPro-MB31
 Provides(90): HiraKakuStdN-W8
 Provides(90): HiraKakuStd-W8
 TTFname(20): yugothib.ttf
-TTFname(21): YuGothic-Bold.ttf
 TTCname(30): YuGothB.ttc(0)
+TTFname(40): YuGothB.ttf
+TTFname(50): YuGothic-Bold.ttf
 
 # IPA (free)
 
@@ -3772,7 +3779,7 @@ Name: Gulim
 Class: Korea
 Provides(50): HYRGoThic-Medium
 Provides(90): HYGoThic-Medium
-TTFname(30): Gulim.ttf
+TTFname(50): Gulim.ttf
 TTCname(20): gulim.ttc(0)
 
 Name: GulimChe
@@ -3819,17 +3826,19 @@ TTCname(20): simsun.ttc(1)
 
 Name: KaiTi
 Class: GB
+TTFname(40): Kaiti.ttf
 TTFname(20): simkai.ttf
 
 Name: FangSong
 Class: GB
+TTFname(40): Fangsong.ttf
 TTFname(20): simfang.ttf
 
 Name: MicrosoftYaHei
 Class: GB
 TTFname: msyh.ttf
 
-Name: MicrosoftYaHeiBold
+Name: MicrosoftYaHei-Bold
 Class: GB
 TTFname: msyhbd.ttf
 
@@ -3923,20 +3932,150 @@ TTCname(20): meiryo.ttc(0)
 Name: Meiryo-Bold
 Class: Japan
 TTFname(50): Meiryo Bold.ttf
+TTFname(40): MeiryoBold.ttf
 TTFname(30): Meiryo-Bold.ttf
 TTCname(20): meiryob.ttc(0)
 
 Name: Meiryo-BoldItalic
 Class: Japan
 TTFname(50): Meiryo Bold Italic.ttf
+TTFname(40): MeiryoBoldItalic.ttf
 TTFname(30): Meiryo-BoldItalic.ttf
 TTCname(20): meiryob.ttc(1)
 
 Name: Meiryo-Italic
 Class: Japan
 TTFname(50): Meiryo Italic.ttf
+TTFname(40): MeiryoItalic.ttf
 TTFname(30): Meiryo-Italic.ttf
 TTCname(20): meiryo.ttc(1)
+
+Name: HGGothicE
+Class: Japan
+TTCname(50): HGRGE.ttc(0)
+TTCname(20): HGRGE.TTC(0)
+
+Name: HGPGothicE
+Class: Japan
+TTCname(50): HGRGE.ttc(1)
+TTCname(20): HGRGE.TTC(1)
+
+Name: HGSGothicE
+Class: Japan
+TTCname(50): HGRGE.ttc(2)
+TTCname(20): HGRGE.TTC(2)
+
+Name: HGGothicM
+Class: Japan
+TTCname(20): HGRGM.TTC(0)
+
+Name: HGPGothicM
+Class: Japan
+TTCname(20): HGRGM.TTC(1)
+
+Name: HGSGothicM
+Class: Japan
+TTCname(20): HGRGM.TTC(2)
+
+Name: HGMinchoE
+Class: Japan
+TTCname(50): HGRME.ttc(0)
+TTCname(20): HGRME.TTC(0)
+
+Name: HGPMinchoE
+Class: Japan
+TTCname(50): HGRME.ttc(1)
+TTCname(20): HGRME.TTC(2)
+
+Name: HGSMinchoE
+Class: Japan
+TTCname(50): HGRME.ttc(2)
+TTCname(20): HGRME.TTC(2)
+
+Name: HGMinchoB
+Class: Japan
+TTCname(20): HGRMB.TTC(0)
+
+Name: HGPMinchoB
+Class: Japan
+TTCname(20): HGRMB.TTC(1)
+
+Name: HGPMinchoB
+Class: Japan
+TTCname(20): HGRMB.TTC(2)
+
+Name: HGSoeiKakugothicUB
+Class: Japan
+TTCname(50): HGRSGU.ttc(0)
+TTCname(20): HGRSGU.TTC(0)
+
+Name: HGPSoeiKakugothicUB
+Class: Japan
+TTCname(50): HGRSGU.ttc(1)
+TTCname(20): HGRSGU.TTC(1)
+
+Name: HGSSoeiKakugothicUB
+Class: Japan
+TTCname(50): HGRSGU.ttc(2)
+TTCname(20): HGRSGU.TTC(2)
+
+Name: HGSoeiKakupoptai
+Class: Japan
+TTCname(20): HGRPP1.TTC(0)
+
+Name: HGPSoeiKakupoptai
+Class: Japan
+TTCname(20): HGRPP1.TTC(1)
+
+Name: HGSSoeiKakupoptai
+Class: Japan
+TTCname(20): HGRPP1.TTC(2)
+
+Name: HGSoeiPresenceEB
+Class: Japan
+TTCname(20): HGRPRE.TTC(0)
+
+Name: HGPSoeiPresenceEB
+Class: Japan
+TTCname(20): HGRPRE.TTC(1)
+
+Name: HGSSoeiPresenceEB
+Class: Japan
+TTCname(20): HGRPRE.TTC(2)
+
+Name: HGKyokashotai
+Class: Japan
+TTCname(20): HGRKK.TTC(0)
+
+Name: HGPKyokashotai
+Class: Japan
+TTCname(20): HGRKK.TTC(1)
+
+Name: HGSKyokashotai
+Class: Japan
+TTCname(20): HGRKK.TTC(2)
+
+Name: HGGyoshotai
+Class: Japan
+TTCname(20): HGRGY.TTC(0)
+
+Name: HGPGyoshotai
+Class: Japan
+TTCname(20): HGRGY.TTC(1)
+
+Name: HGSGyoshotai
+Class: Japan
+TTCname(20): HGRGY.TTC(2)
+
+Name: HGMaruGothicMPRO
+Class: Japan
+TTFname(40): HGRSMP.ttf
+TTFname(20): HGRSMP.TTF
+
+Name: HGSeikaishotaiPRO
+Class: Japan
+TTFname(20): HGRSKP.TTF
+
 
 ### Local Variables:
 ### perl-indent-level: 2

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -843,7 +843,7 @@ sub maybe_symlink {
       # }
       # -- however, both tlgs (TeX Live) and standalone gswin32/64 (built
       #    by Akira Kakuto) can search in c:/windows/fonts by default.
-      #    Thus, creating hard link for such files is waste of memory
+      #    Thus, copying such files is waste of memory
     }
   } else {
     symlink ($realname, $targetname);

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -354,7 +354,7 @@ sub main {
   if ($opt_winbatch) {
     if (win32()) {
       $opt_winbatch = 1;
-      unlink $winbatch if (-e $winbatch);
+      unlink $winbatch if (-f $winbatch);
     } else {
       print_warning("ignoring --winbatch option due to non-Windows\n");
       $opt_winbatch = 0;
@@ -456,7 +456,7 @@ sub main {
   do_aliases();
   write_akotfps_datafile() if ($opt_akotfps);
   print_info("finished\n");
-  if ($opt_winbatch && -e $winbatch) {
+  if ($opt_winbatch && -f $winbatch) {
     print_info("*** Batch file $winbatch created ***\n");
     print_info("*** to complete, run it as administrator privilege.***\n");
   }
@@ -1088,6 +1088,8 @@ sub check_for_files {
     my $bn = basename($f);
     $bntofn{$bn} = $realf;
   }
+
+  # show the %fontdb before file check
   if ($opt_debug > 0) {
     print_debug("dumping font database before file check:\n");
     print_debug(Data::Dumper::Dumper(\%fontdb));

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -287,6 +287,7 @@ if (! GetOptions(
 }
 
 sub win32 { return ($^O=~/^MSWin(32|64)$/i); }
+sub macosx { return ($^O=~/^darwin$/i); }
 my $nul = (win32() ? 'nul' : '/dev/null') ;
 my $sep = (win32() ? ';' : ':');
 my %fontdb;
@@ -946,6 +947,13 @@ sub check_for_files {
       # other dirs to check, for normal unix?
       for my $d (qw!/Library/Fonts /System/Library/Fonts /System/Library/Assets /Network/Library/Fonts /usr/share/fonts!) {
         push @extradirs, "$d//" if (-d $d); # recursive search
+      }
+      # macosx specific; the path contains white space, so hack required
+      for my $d (qw!/Applications/Microsoft__Word.app /Applications/Microsoft__Excel.app /Applications/Microsoft__PowerPoint.app!) {
+        my $sd = $d;
+        $sd =~ s/_/ /;
+        push @extradirs, "$sd/Contents/Resources/Fonts/" if (-d "$sd/Contents/Resources/Fonts");
+        push @extradirs, "$sd/Contents/Resources/DFonts/" if (-d "$sd/Contents/Resources/DFonts");
       }
       my $home = $ENV{'HOME'};
       push @extradirs, "$home/Library/Fonts//" if (-d "$home/Library/Fonts");

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -406,20 +406,16 @@ sub main {
       die ("Cannot create directory $opt_output: $!");
   }
   print_info("output is going to $opt_output\n");
-
-  init_akotfps_datafile() if ($opt_akotfps);
   if (!$opt_only_aliases) {
-    init_winbatch() if (win32());
     print_info(($opt_remove ? "removing" : "generating") . " font snippets and link CID fonts ...\n");
     do_otf_fonts();
     print_info(($opt_remove ? "removing" : "generating") . " font snippets, links, and cidfmap.local for TTF fonts ...\n");
     do_nonotf_fonts();
-    complete_winbatch() if (win32());
+    write_winbatch() if (win32());
   }
   print_info(($opt_remove ? "removing" : "generating") . " font aliases ...\n");
   do_aliases();
-  complete_akotfps_datafile() if ($opt_akotfps);
-
+  write_akotfps_datafile() if ($opt_akotfps);
   print_info("finished\n");
 }
 
@@ -805,32 +801,23 @@ sub maybe_symlink {
   }
 }
 
-# initialize batch file (windows only)
-sub init_winbatch {
+# write batch file (windows only)
+sub write_winbatch {
   return if $dry_run;
   open(FOO, ">$winbatch") || 
     die("cannot open $winbatch for writing: $!");
-  print FOO "\@echo off\n";
+  print FOO "\@echo off\n",
+            "$winbatch_content",
+            "\@echo symlink generated\n",
+            "\@pause 1\n";
   close(FOO);
 }
 
-# complete batch file (windows only)
-sub complete_winbatch {
-  return if $dry_run;
-  open(FOO, ">>$winbatch") || 
-    die("cannot open $winbatch for writing: $!");
-  print FOO "$winbatch_content";
-  print FOO "\@echo symlink generated\n";
-  print FOO "\@pause 1\n";
-  close(FOO);
-}
-
-# initialize psnames-for-otfps
-sub init_akotfps_datafile {
+# write to psnames-for-otfps
+sub write_akotfps_datafile {
   return if $dry_run;
   make_dir("$opt_akotfps/$akotfps_pathpart",
-         "cannot create $akotfps_datafilename in it!")
-  if $opt_akotfps;
+         "cannot create $akotfps_datafilename in it!");
   open(FOO, ">$opt_akotfps/$akotfps_pathpart/$akotfps_datafilename") || 
     die("cannot open $opt_akotfps/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
   print FOO "% psnames-for-otf
@@ -841,16 +828,7 @@ sub init_akotfps_datafile {
 % in order to add needed information to a ps file
 % created by the dvips
 %
-";
-  close(FOO);
-}
-
-# write to psnames-for-otfps
-sub complete_akotfps_datafile {
-  return if $dry_run;
-  open(FOO, ">>$opt_akotfps/$akotfps_pathpart/$akotfps_datafilename") || 
-    die("cannot open $opt_akotfps/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
-  print FOO "$akotfps_datacontent";
+$akotfps_datacontent";
   close(FOO);
 }
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -237,6 +237,12 @@ my %encode_list = (
 my $otf_pathpart = "fonts/opentype/cjk-gs-integrate";
 my $ttf_pathpart = "fonts/truetype/cjk-gs-integrate";
 
+# location where cidfmap, cidfmap.local and cidfmap.aliases are placed
+# when found gs is tlgs (win32), then files will be placed in lib/ instead of Resource/Init/
+my $cidfmap_pathpart = "Init/cidfmap";
+my $cidfmap_local_pathpart = "Init/cidfmap.local";
+my $cidfmap_aliases_pathpart = "Init/cidfmap.aliases";
+
 # support for ps2otfps by Akira Kakuto
 my $akotfps_pathpart = "dvips/ps2otfps";
 my $akotfps_datafilename = "psnames-for-otf";
@@ -439,11 +445,15 @@ sub main {
   do_aliases();
   write_akotfps_datafile() if ($opt_akotfps);
   print_info("finished\n");
+  if ($opt_winbatch) {
+    print_info("I created $winbatch, to help you create symlinks.\n");
+    print_info("to complete, run it as administrator privilege.\n");
+  }
 }
 
 sub update_master_cidfmap {
   my $add = shift;
-  my $cidfmap_master = "$opt_output/Init/cidfmap";
+  my $cidfmap_master = "$opt_output/$cidfmap_pathpart";
   print_info(sprintf("%s $add %s cidfmap file ...\n", 
     ($opt_remove ? "removing" : "adding"), ($opt_remove ? "from" : "to")));
   if (-r $cidfmap_master) {
@@ -678,8 +688,8 @@ sub do_nonotf_fonts {
       mkdir("$opt_output/Init") ||
         die("Cannot create directory $opt_output/Init: $!");
     }
-    open(FOO, ">$opt_output/Init/cidfmap.local") || 
-      die "Cannot open $opt_output/cidfmap.local: $!";
+    open(FOO, ">$opt_output/$cidfmap_local_pathpart") || 
+      die "Cannot open $opt_output/$cidfmap_local_pathpart: $!";
     print FOO $outp;
     close(FOO);
   }
@@ -758,8 +768,8 @@ sub do_aliases {
       mkdir("$opt_output/Init") ||
         die("Cannot create directory $opt_output/Init: $!");
     }
-    open(FOO, ">$opt_output/Init/cidfmap.aliases") || 
-      die "Cannot open $opt_output/cidfmap.aliases: $!";
+    open(FOO, ">$opt_output/$cidfmap_aliases_pathpart") || 
+      die "Cannot open $opt_output/$cidfmap_aliases_pathpart: $!";
     print FOO $outp;
     close(FOO);
   }
@@ -1371,6 +1381,10 @@ sub find_gs_resource {
         print_error("we cannot support such gs, sorry.\n");
         $foundres = '';
       }
+      # change output location
+      $cidfmap_pathpart = "../lib/cidfmap";
+      $cidfmap_local_pathpart = "../lib/cidfmap.local";
+      $cidfmap_aliases_pathpart = "../lib/cidfmap.aliases";
     } else {
       # TODO: we assume gswin32c is in the path
       # paths other than c:/gs/gs$gsver/Resource are not considered
@@ -1502,6 +1516,7 @@ my $operation = "
 For each found TrueType (TTF) font it creates a cidfmap entry in
 
     <Resource>/Init/cidfmap.local
+      -- if you are using tlgs win32, tlpkg/tlgs/lib/cidfmap.local instead
 
 and links the font to
 
@@ -1521,10 +1536,12 @@ from an installed GhostScript (binary name is assumed to be 'gs').
 Aliases are added to 
 
     <Resource>/Init/cidfmap.aliases
+      -- if you are using tlgs win32, tlpkg/tlgs/lib/cidfmap.aliases instead
 
 Finally, it tries to add runlib calls to
 
     <Resource>/Init/cidfmap
+      -- if you are using tlgs win32, tlpkg/tlgs/lib/cidfmap
 
 to load the cidfmap.local and cidfmap.aliases.
 ";

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2597,6 +2597,16 @@ Name: Sazanami-Gothic-Regular
 Class: Japan
 TTFname: sazanami-gothic.ttf
 
+# Osaka (Apple)
+
+Name: Osaka
+Class: Japan
+TTFname: Osaka.ttf
+
+Name: Osaka-Mono
+Class: Japan
+TTFname: OsakaMono.ttf
+
 # Kozuka (Adobe)
 
 Name: KozGoPr6N-Bold
@@ -2917,6 +2927,54 @@ Class: CNS
 #Provides(??): MSung-Light # fails
 TTFname(20): 儷宋 Pro.ttf
 TTFname(10): LiSongPro.ttf
+
+Name: PingFangTC-Regular
+Class: CNS
+OTCname: PingFang.ttc(1)
+
+Name: PingFangSC-Regular
+Class: GB
+OTCname: PingFang.ttc(2)
+
+Name: PingFangTC-Medium
+Class: CNS
+OTCname: PingFang.ttc(4)
+
+Name: PingFangSC-Medium
+Class: GB
+OTCname: PingFang.ttc(5)
+
+Name: PingFangTC-Semibold
+Class: CNS
+OTCname: PingFang.ttc(7)
+
+Name: PingFangSC-Semibold
+Class: GB
+OTCname: PingFang.ttc(8)
+
+Name: PingFangTC-Light
+Class: CNS
+OTCname: PingFang.ttc(10)
+
+Name: PingFangSC-Light
+Class: GB
+OTCname: PingFang.ttc(11)
+
+Name: PingFangTC-Thin
+Class: CNS
+OTCname: PingFang.ttc(13)
+
+Name: PingFangSC-Thin
+Class: GB
+OTCname: PingFang.ttc(14)
+
+Name: PingFangTC-Ultralight
+Class: CNS
+OTCname: PingFang.ttc(16)
+
+Name: PingFangSC-Ultralight
+Class: GB
+OTCname: PingFang.ttc(17)
 
 # Changzhou SinoType (OS X)
 
@@ -3245,6 +3303,11 @@ Name: WawaSC-Regular
 PSName: DFWaWaSC-W5
 Class: GB
 OTFname: WawaSC-Regular.otf
+
+Name: WawaTC-Regular
+PSName: DFWaWaTC-W5
+Class: CNS
+OTFname: WawaTC-Regular.otf
 
 Name: HannotateSC-W5
 Class: GB
@@ -3727,41 +3790,50 @@ Class: Korea
 #Provides(??): HYRGoThic-Medium # fails
 TTFname: AppleGothic.ttf
 
-Name: AppleSDGothicNeo-Thin
-Class: Korea
-OTFname: AppleSDGothicNeo-Thin.otf
-
-Name: AppleSDGothicNeo-UltraLight
-Class: Korea
-OTFname: AppleSDGothicNeo-UltraLight.otf
-
-Name: AppleSDGothicNeo-Light
-Class: Korea
-OTFname: AppleSDGothicNeo-Light.otf
-
 Name: AppleSDGothicNeo-Regular
 Class: Korea
-OTFname: AppleSDGothicNeo-Regular.otf
+OTFname(10): AppleSDGothicNeo-Regular.otf
+OTCname(20): AppleSDGothicNeo.ttc(0)
 
 Name: AppleSDGothicNeo-Medium
 Class: Korea
-OTFname: AppleSDGothicNeo-Medium.otf
+OTFname(10): AppleSDGothicNeo-Medium.otf
+OTCname(20): AppleSDGothicNeo.ttc(2)
 
 Name: AppleSDGothicNeo-SemiBold
 Class: Korea
-OTFname: AppleSDGothicNeo-SemiBold.otf
+OTFname(10): AppleSDGothicNeo-SemiBold.otf
+OTCname(20): AppleSDGothicNeo.ttc(4)
 
 Name: AppleSDGothicNeo-Bold
 Class: Korea
-OTFname: AppleSDGothicNeo-Bold.otf
+OTFname(10): AppleSDGothicNeo-Bold.otf
+OTCname(20): AppleSDGothicNeo.ttc(6)
+
+Name: AppleSDGothicNeo-Light
+Class: Korea
+OTFname(10): AppleSDGothicNeo-Light.otf
+OTCname(20): AppleSDGothicNeo.ttc(8)
+
+Name: AppleSDGothicNeo-Thin
+Class: Korea
+OTFname(10): AppleSDGothicNeo-Thin.otf
+OTCname(20): AppleSDGothicNeo.ttc(10)
+
+Name: AppleSDGothicNeo-UltraLight
+Class: Korea
+OTFname(10): AppleSDGothicNeo-UltraLight.otf
+OTCname(20): AppleSDGothicNeo.ttc(12)
 
 Name: AppleSDGothicNeo-ExtraBold
 Class: Korea
-OTFname: AppleSDGothicNeo-ExtraBold.otf
+OTFname(10): AppleSDGothicNeo-ExtraBold.otf
+OTCname(20): AppleSDGothicNeo.ttc(14)
 
 Name: AppleSDGothicNeo-Heavy
 Class: Korea
-OTFname: AppleSDGothicNeo-Heavy.otf
+OTFname(10): AppleSDGothicNeo-Heavy.otf
+OTCname(20): AppleSDGothicNeo.ttc(16)
 
 Name: JCsmPC
 Class: Korea
@@ -3774,6 +3846,10 @@ TTFname: Pilgiche.ttf
 Name: JCkg
 Class: Korea
 TTFname: Gungseouche.ttf
+
+Name: JCHEadA
+Class: Korea
+TTFname: HeadlineA.ttf
 
 # Adobe korean fonts
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -248,51 +248,51 @@ my $akotfps_pathpart = "dvips/ps2otfps";
 my $akotfps_datafilename = "psnames-for-otf";
 my $akotfps_datacontent = '';
 
-my $dry_run = 0;
-my $opt_help = 0;
-my $opt_quiet = 0;
-my $opt_debug = 0;
+my $opt_output;
+my $opt_fontdef;
+my @opt_aliases;
+my $opt_filelist;
+my $opt_texmflink;
+my $opt_akotfps;
+my $opt_force = 0;
+my $opt_remove = 0;
+my $opt_hardlink = 0;
+my $opt_winbatch = 0;
+my $opt_only_aliases = 0;
 my $opt_listaliases = 0;
 my $opt_listallaliases = 0;
 my $opt_listfonts = 0;
-my $opt_remove = 0;
 my $opt_info = 0;
-my $opt_fontdef;
-my $opt_output;
-my @opt_aliases;
-my $opt_only_aliases = 0;
 my $opt_machine = 0;
-my $opt_filelist;
-my $opt_force = 0;
-my $opt_texmflink;
-my $opt_akotfps;
-my $opt_winbatch = 0;
-my $opt_hardlink = 0;
+my $dry_run = 0;
+my $opt_quiet = 0;
+my $opt_debug = 0;
+my $opt_help = 0;
 my $opt_markdown = 0;
 
 if (! GetOptions(
-        "n|dry-run"   => \$dry_run,
-        "info"        => \$opt_info,
+        "o|output=s"  => \$opt_output,
+        "f|fontdef=s" => \$opt_fontdef,
+        "a|alias=s"   => \@opt_aliases,
+        "filelist=s"  => \$opt_filelist,
+        "link-texmf:s" => \$opt_texmflink,
+        "otfps:s"      => \$opt_akotfps,
+        "force"       => \$opt_force,
+        "remove"       => \$opt_remove,
+        "hardlink"     => \$opt_hardlink,
+        "winbatch"     => \$opt_winbatch,
+        "only-aliases" => \$opt_only_aliases,
         "list-aliases" => \$opt_listaliases,
         "list-all-aliases" => \$opt_listallaliases,
         "list-fonts"  => \$opt_listfonts,
-        "link-texmf:s" => \$opt_texmflink,
-        "otfps:s"      => \$opt_akotfps,
-        "winbatch"     => \$opt_winbatch,
-        "hardlink"     => \$opt_hardlink,
-        "remove"       => \$opt_remove,
-        "only-aliases" => \$opt_only_aliases,
+        "info"        => \$opt_info,
         "machine-readable" => \$opt_machine,
-        "force"       => \$opt_force,
-        "filelist=s"  => \$opt_filelist,
-        "markdown"    => \$opt_markdown,
-        "o|output=s"  => \$opt_output,
-        "h|help"      => \$opt_help,
+        "n|dry-run"   => \$dry_run,
         "q|quiet"     => \$opt_quiet,
         "d|debug+"    => \$opt_debug,
-        "f|fontdef=s" => \$opt_fontdef,
-        "a|alias=s"   => \@opt_aliases,
         "v|version"   => sub { print &version(); exit(0); }, ) ) {
+        "h|help"      => \$opt_help,
+        "markdown"    => \$opt_markdown,
   die "Try \"$0 --help\" for more information.\n";
 }
 
@@ -1494,13 +1494,11 @@ sub Usage {
   my $headline = "Configuring GhostScript for CJK CID/TTF fonts";
   my $usage = "[perl] $prg\[.pl\] [OPTIONS]";
   my $options = "
--n, --dry-run         do not actually output anything
---remove              try to remove instead of create
--f, --fontdef FILE    specify alternate set of font definitions, if not
-                      given, the built-in set is used
 -o, --output DIR      specifies the base output dir, if not provided,
                       the Resource directory of an installed GhostScript
                       is searched and used.
+-f, --fontdef FILE    specify alternate set of font definitions, if not
+                      given, the built-in set is used
 -a, --alias LL=RR     defines an alias, or overrides a given alias;
                       illegal if LL is provided by a real font, or
                       RR is neither available as real font or alias;
@@ -1517,6 +1515,8 @@ sub Usage {
                       which is used by ps2otfps (developed by Akira Kakuto),
                       instead of generating snippets
 --force               do not bail out if linked fonts already exist
+--remove              try to remove instead of create
+-n, --dry-run         do not actually output anything
 -q, --quiet           be less verbose
 -d, --debug           output debug information, can be given multiple times
 -v, --version         outputs only the version information

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -753,6 +753,60 @@ sub generate_cidfmap_entry {
   return $s;
 }
 
+sub maybe_symlink {
+  my ($realname, $targetname) = @_;
+  if (win32()) {
+#    open(FOO, ">$targetname") || 
+#      die("cannot open $targetname for writing: $!");
+#    print FOO "$realname";
+#    close(FOO);
+    open(FOO, ">>$winbatch") || 
+      die("cannot open $winbatch for writing: $!");
+    $realname =~ s!/!\\!g;
+    $targetname =~ s!/!\\!g;
+    print FOO "mklink $targetname $realname\n";
+    close(FOO);
+  } else {
+    symlink ($realname, $targetname);
+  }
+}
+
+# initialize batch file (windows only)
+sub init_winbatch {
+  open(FOO, ">$winbatch") || 
+    die("cannot open $winbatch for writing: $!");
+  print FOO "\@echo off\n";
+  close(FOO);
+}
+
+# complete batch file (windows only)
+sub complete_winbatch {
+  open(FOO, ">>$winbatch") || 
+    die("cannot open $winbatch for writing: $!");
+  print FOO "\@echo symlink generated\n";
+  print FOO "\@pause 1\n";
+  close(FOO);
+}
+
+# initialize psnames-for-otfps
+sub init_akotfps_datafile {
+  make_dir("$opt_texmflink/$akotfps_pathpart",
+         "cannot create $akotfps_datafilename in it!")
+  if $opt_texmflink;
+  open(FOO, ">$opt_texmflink/$akotfps_pathpart/$akotfps_datafilename") || 
+    die("cannot open $opt_texmflink/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
+  print FOO "% psnames-for-otf
+%
+% PostSctipt names for OpenType fonts
+%
+% This file is used by a program ps2otfps
+% in order to add needed information to a ps file
+% created by the dvips
+%
+";
+  close(FOO);
+}
+
 #
 # dump found files
 sub info_found_fonts {
@@ -1440,60 +1494,6 @@ sub print_for_out {
       print "$indent$_\n";
     }
   }
-}
-
-sub maybe_symlink {
-  my ($realname, $targetname) = @_;
-  if (win32()) {
-#    open(FOO, ">$targetname") || 
-#      die("cannot open $targetname for writing: $!");
-#    print FOO "$realname";
-#    close(FOO);
-    open(FOO, ">>$winbatch") || 
-      die("cannot open $winbatch for writing: $!");
-    $realname =~ s!/!\\!g;
-    $targetname =~ s!/!\\!g;
-    print FOO "mklink $targetname $realname\n";
-    close(FOO);
-  } else {
-    symlink ($realname, $targetname);
-  }
-}
-
-# initialize batch file (windows only)
-sub init_winbatch {
-  open(FOO, ">$winbatch") || 
-    die("cannot open $winbatch for writing: $!");
-  print FOO "\@echo off\n";
-  close(FOO);
-}
-
-# complete batch file (windows only)
-sub complete_winbatch {
-  open(FOO, ">>$winbatch") || 
-    die("cannot open $winbatch for writing: $!");
-  print FOO "\@echo symlink generated\n";
-  print FOO "\@pause 1\n";
-  close(FOO);
-}
-
-# initialize psnames-for-otfps
-sub init_akotfps_datafile {
-  make_dir("$opt_texmflink/$akotfps_pathpart",
-         "cannot create $akotfps_datafilename in it!")
-  if $opt_texmflink;
-  open(FOO, ">$opt_texmflink/$akotfps_pathpart/$akotfps_datafilename") || 
-    die("cannot open $opt_texmflink/$akotfps_pathpart/$akotfps_datafilename for writing: $!");
-  print FOO "% psnames-for-otf
-%
-% PostSctipt names for OpenType fonts
-%
-% This file is used by a program ps2otfps
-% in order to add needed information to a ps file
-% created by the dvips
-%
-";
-  close(FOO);
 }
 
 # info/warning can be suppressed

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -3744,7 +3744,7 @@ Class: Korea
 OTFname: AdobeGothicStd-Light.otf
 
 #
-# Microsoft Mac Office fonts
+# Microsoft Windows, Windows/Mac Office fonts
 #
 
 # korea
@@ -3753,13 +3753,47 @@ Name: Batang
 Class: Korea
 Provides(50): HYSMyeongJo-Medium
 TTFname(50): Batang.ttf
+TTCname(20): batang.ttc(0)
+
+Name: BatangChe
+Class: Korea
+TTCname(20): batang.ttc(1)
+
+Name: Dotum
+Class: Korea
+Provides(50): HYGoThic-Medium
+TTCname(20): gulim.ttc(2)
+
+Name: DotumChe
+Class: Korea
+TTCname(20): gulim.ttc(3)
 
 Name: Gulim
 Class: Korea
 Provides(50): HYRGoThic-Medium
 Provides(90): HYGoThic-Medium
 TTFname(30): Gulim.ttf
-TTCname(50): gulim.ttc
+TTCname(20): gulim.ttc(0)
+
+Name: GulimChe
+Class: Korea
+TTCname(20): gulim.ttc(1)
+
+Name: Gungsuh
+Class: Korea
+TTCname(20): batang.ttc(2)
+
+Name: GungsuhChe
+Class: Korea
+TTCname(20): batang.ttc(3)
+
+Name: MalgunGothicRegular
+Class: Korea
+TTFname: malgun.ttf
+
+Name: MalgunGothicBold
+Class: Korea
+TTFname: malgunbd.ttf
 
 # simplified chinese
 
@@ -3769,6 +3803,7 @@ Provides(60): STHeiti-Regular
 Provides(60): STKaiti-Regular
 Provides(60): STHeiti-Light
 TTFname(50): SimHei.ttf
+TTFname(20): simhei.ttf
 
 Name: SimSun
 Class: GB
@@ -3776,6 +3811,27 @@ Provides(60): STSong-Light
 Provides(60): STFangsong-Light
 Provides(60): STFangsong-Regular
 TTFname(50): SimSun.ttf
+TTCname(20): simsun.ttc(0)
+
+Name: NSimSun
+Class: GB
+TTCname(20): simsun.ttc(1)
+
+Name: KaiTi
+Class: GB
+TTFname(20): simkai.ttf
+
+Name: FangSong
+Class: GB
+TTFname(20): simfang.ttf
+
+Name: MicrosoftYaHei
+Class: GB
+TTFname: msyh.ttf
+
+Name: MicrosoftYaHeiBold
+Class: GB
+TTFname: msyhbd.ttf
 
 # traditional chinese
 
@@ -3786,10 +3842,24 @@ Provides(60): MKai-Medium
 Provides(60): MSung-Medium
 Provides(60): MSung-Light
 TTFname(50): MingLiU.ttf
+TTCname(20): mingliu.ttc(0)
 
 Name: PMingLiU
 Class: CNS
 TTFname(50): PMingLiU.ttf
+TTCname(20): mingliu.ttc(1)
+
+Name: DFKaiShu-SB-Estd-BF
+Class: CNS
+TTFname: kaiu.ttf
+
+Name: MicrosoftJhengHeiRegular
+Class: CNS
+TTFname: msjh.ttf
+
+Name: MicrosoftJhengHeiBold
+Class: CNS
+TTFname: msjhbd.ttf
 
 # japanese
 
@@ -3813,6 +3883,7 @@ Provides(95): HiraMaruProN-W4
 Provides(95): HiraMaruPro-W4
 TTFname(50): MS Gothic.ttf
 TTFname(30): MS-Gothic.ttf
+TTCname(20): msgothic.ttc(0)
 
 Name: MS-Mincho
 Class: Japan
@@ -3826,36 +3897,46 @@ Provides(95): HiraMinProN-W6
 Provides(95): HiraMinPro-W6
 TTFname(50): MS Mincho.ttf
 TTFname(30): MS-Mincho.ttf
+TTCname(20): msmincho.ttc(0)
 
 Name: MS-PGothic
 Class: Japan
 TTFname(50): MS PGothic.ttf
 TTFname(30): MS-PGothic.ttf
+TTCname(20): msgothic.ttc(1)
 
 Name: MS-PMincho
 Class: Japan
 TTFname(50): MS PMincho.ttf
 TTFname(30): MS-PMincho.ttf
+TTCname(20): msmincho.ttc(1)
+
+Name: MS-UIGothic
+Class: Japan
+TTCname(20): msgothic.ttc(2)
 
 Name: Meiryo
 Class: Japan
 TTFname(50): Meiryo.ttf
+TTCname(20): meiryo.ttc(0)
 
 Name: Meiryo-Bold
 Class: Japan
 TTFname(50): Meiryo Bold.ttf
 TTFname(30): Meiryo-Bold.ttf
+TTCname(20): meiryob.ttc(0)
 
 Name: Meiryo-BoldItalic
 Class: Japan
 TTFname(50): Meiryo Bold Italic.ttf
 TTFname(30): Meiryo-BoldItalic.ttf
+TTCname(20): meiryob.ttc(1)
 
 Name: Meiryo-Italic
 Class: Japan
 TTFname(50): Meiryo Italic.ttf
 TTFname(30): Meiryo-Italic.ttf
-
+TTCname(20): meiryo.ttc(1)
 
 ### Local Variables:
 ### perl-indent-level: 2

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1370,12 +1370,27 @@ sub read_font_database {
 sub find_gs_resource {
   my $foundres = '';
   if (win32()) {
-    # TODO: currently we assume native gs, and gswin32c is in the path
-    # paths other than c:/gs/gs$gsver/Resource are not considered
-    chomp( my $gsver = `gswin32c --version 2>$nul` );
-    $foundres = "c:/gs/gs$gsver/Resource";
-    if ( ! -d $foundres ) {
-      $foundres = '';
+    # determine tlgs or native gs
+    chomp( my $foo = `kpsewhich -var-value=SELFAUTOPARENT`);
+    if ( -d "$foo/tlpkg/tlgs" ) {
+      # should be texlive with tlgs
+      if ( -d "$foo/tlpkg/tlgs/Resource" ) {
+        $foundres = "$foo/tlpkg/tlgs/Resource";
+      } else {
+        # TODO: for TL2016, tlgs binary has built-in Resource,
+        # so no Resource directory is available!
+        print_error("No Resource directory available for tlgs,\n");
+        print_error("we cannot support such gs, sorry.\n");
+        $foundres = '';
+      }
+    } else {
+      # TODO: we assume gswin32c is in the path
+      # paths other than c:/gs/gs$gsver/Resource are not considered
+      chomp( my $gsver = `gswin32c --version 2>$nul` );
+      $foundres = "c:/gs/gs$gsver/Resource";
+      if ( ! -d $foundres ) {
+        $foundres = '';
+      }
     }
   } else {
     # we assume that gs is in the path

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -482,22 +482,31 @@ sub update_master_cidfmap {
       }
     }
     close(FOO);
-    if ($found) {
-      if ($opt_remove) {
+    # if the master cidfmap has a new line at end of file,
+    # then $newmaster should end with "\n".
+    # otherwise we add a new line, since there is a possibility of %EOF comment
+    # without trailing new line (e.g. TL before r44039)
+    $newmaster =~ s/\n$//g;
+    $newmaster =~ s/$/\n/g;
+    if ($opt_remove) {
+      if ($found) {
+        return if $dry_run;
         open(FOO, ">", $cidfmap_master) ||
           die ("Cannot clean up $cidfmap_master: $!");
         print FOO $newmaster;
         close FOO;
-      } else {
-        print_info("$add already loaded in $cidfmap_master, no changes\n");
       }
     } else {
-      return if $dry_run;
-      return if $opt_remove;
-      open(FOO, ">>", $cidfmap_master) ||
-        die ("Cannot open $cidfmap_master for appending: $!");
-      print FOO "($add) .runlibfile\n";
-      close(FOO);
+      if ($found) {
+        print_info("$add already loaded in $cidfmap_master, no changes\n");
+      } else {
+        return if $dry_run;
+        open(FOO, ">", $cidfmap_master) ||
+          die ("Cannot clean up $cidfmap_master: $!");
+        print FOO $newmaster;
+        print FOO "($add) .runlibfile\n";
+        close(FOO);
+      }
     }
   } else {
     return if $dry_run;

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1508,7 +1508,7 @@ sub Usage {
 
   my $winonlyoptions = "
 --hardlink            create hardlinks instead of symlinks
---winbatch            generate batch file for link generation, instead of
+--winbatch            prepare a batch file for link generation, instead of
                       generating links right away
 ";
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -3971,7 +3971,6 @@ TTFname: malgunsl.ttf
 Name: SimHei
 Class: GB
 Provides(60): STHeiti-Regular
-Provides(60): STKaiti-Regular
 Provides(60): STHeiti-Light
 TTFname(50): SimHei.ttf
 TTFname(20): simhei.ttf
@@ -3979,8 +3978,6 @@ TTFname(20): simhei.ttf
 Name: SimSun
 Class: GB
 Provides(60): STSong-Light
-Provides(60): STFangsong-Light
-Provides(60): STFangsong-Regular
 TTFname(50): SimSun.ttf
 TTCname(20): simsun.ttc(0)
 
@@ -3990,11 +3987,14 @@ TTCname(20): simsun.ttc(1)
 
 Name: KaiTi
 Class: GB
+Provides(60): STKaiti-Regular
 TTFname(40): Kaiti.ttf
 TTFname(20): simkai.ttf
 
 Name: FangSong
 Class: GB
+Provides(60): STFangsong-Light
+Provides(60): STFangsong-Regular
 TTFname(40): Fangsong.ttf
 TTFname(20): simfang.ttf
 
@@ -4049,8 +4049,6 @@ TTFname: STHUPO.ttf
 
 Name: MingLiU
 Class: CNS
-Provides(60): MHei-Medium
-Provides(60): MKai-Medium
 Provides(60): MSung-Medium
 Provides(60): MSung-Light
 TTFname(50): MingLiU.ttf
@@ -4063,11 +4061,13 @@ TTCname(20): mingliu.ttc(1)
 
 Name: DFKaiShu-SB-Estd-BF
 Class: CNS
+Provides(60): MKai-Medium
 TTFname(50): BiauKai.ttf
 TTFname(20): kaiu.ttf
 
 Name: MicrosoftJhengHeiRegular
 Class: CNS
+Provides(60): MHei-Medium
 TTFname(40): MSJH.ttf
 TTFname(20): msjh.ttf
 TTCname(30): msjh.ttc(0)
@@ -4081,6 +4081,15 @@ TTCname(30): msjhbd.ttc(0)
 Name: MicrosoftJhengHeiLight
 Class: CNS
 TTCname(30): msjhl.ttc(0)
+
+Name: MicrosoftMHei
+Class: CNS
+Provides(65): MHei-Medium
+TTFname(10): MSMHei.ttf
+
+Name: MicrosoftMHei-Bold
+Class: CNS
+TTFname(10): MSMHei-Bold.ttf
 
 # japanese
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -823,10 +823,8 @@ sub maybe_symlink {
       $winbatch_content .= "if not exist \"$targetname\" mklink /h \"$targetname\" \"$realname\"\n";
     } else {
       # should be encoded in cp932 for win32 console
-      $realname = Encode::decode('utf-8', $realname);
-      $realname = Encode::encode('cp932', $realname);
-      $targetname = Encode::decode('utf-8', $targetname);
-      $targetname = Encode::encode('cp932', $targetname);
+      $realname = encode_utftocp($realname);
+      $targetname = encode_utftocp($targetname);
       my $cmdl = "cmd.exe /c if not exist \"$targetname\" mklink /h \"$targetname\" \"$realname\"";
       my @ret = `$cmdl`;
       # sometimes hard link creation may fail due to "Access denied"
@@ -862,8 +860,7 @@ sub maybe_unlink {
       $winbatch_content .= "if exist \"$targetname\" del \"$targetname\"\n";
     } else {
       # should be encoded in cp932 for win32 console
-      $targetname = Encode::decode('utf-8', $targetname);
-      $targetname = Encode::encode('cp932', $targetname);
+      $targetname = encode_utftocp($targetname);
       my $cmdl = "cmd.exe /c if exist \"$targetname\" del \"$targetname\"";
       my @ret = `$cmdl`;
     }
@@ -879,8 +876,7 @@ sub write_winbatch {
     die("cannot open $winbatch for writing: $!");
   # $winbatch_content may contain multibyte characters, and they
   # should be encoded in cp932 in batch file
-  $winbatch_content = Encode::decode('utf-8', $winbatch_content);
-  $winbatch_content = Encode::encode('cp932', $winbatch_content);
+  $winbatch_content = encode_utftocp($winbatch_content);
   print FOO "\@echo off\n",
             "$winbatch_content",
             "\@echo symlink ", ($opt_remove ? "removed\n" : "generated\n"),
@@ -1035,8 +1031,7 @@ sub check_for_files {
     # this call (derived from the database) contains multibyte characters,
     # and they should be encoded in cp932 for win32 console
     if (win32()) {
-      $cmdl = Encode::decode('utf-8', $cmdl);
-      $cmdl = Encode::encode('cp932', $cmdl);
+      $cmdl = encode_utftocp($cmdl);
     }
     print_ddebug("checking for $cmdl\n");
     @foundfiles = `$cmdl`;
@@ -1055,10 +1050,8 @@ sub check_for_files {
     }
     # decode now on windows! (cp932 -> internal utf-8)
     if (win32()) {
-      $f = Encode::decode('cp932', $f);
-      $f = Encode::encode('utf-8', $f);
-      $realf = Encode::decode('cp932', $realf);
-      $realf = Encode::encode('utf-8', $realf);
+      $f = encode_cptoutf($f);
+      $realf = encode_cptoutf($realf);
     }
     my $bn = basename($f);
     $bntofn{$bn} = $realf;
@@ -1281,8 +1274,7 @@ sub read_font_database {
       # cp932 for win32 console
       my $encoded_fn;
       if (win32()) {
-        $encoded_fn = Encode::decode('utf-8', $fn);
-        $encoded_fn = Encode::encode('cp932', $encoded_fn);
+        $encoded_fn = encode_utftocp($fn);
       }
       print_ddebug("filename: ", ($encoded_fn ? "$encoded_fn" : "$fn"), "\n");
       print_ddebug("type: otf\n");
@@ -1295,8 +1287,7 @@ sub read_font_database {
       # cp932 for win32 console
       my $encoded_fn;
       if (win32()) {
-        $encoded_fn = Encode::decode('utf-8', $fn);
-        $encoded_fn = Encode::encode('cp932', $encoded_fn);
+        $encoded_fn = encode_utftocp($fn);
       }
       print_ddebug("filename: ", ($encoded_fn ? "$encoded_fn" : "$fn"), "\n");
       print_ddebug("type: otc\n");
@@ -1309,8 +1300,7 @@ sub read_font_database {
       # cp932 for win32 console
       my $encoded_fn;
       if (win32()) {
-        $encoded_fn = Encode::decode('utf-8', $fn);
-        $encoded_fn = Encode::encode('cp932', $encoded_fn);
+        $encoded_fn = encode_utftocp($fn);
       }
       print_ddebug("filename: ", ($encoded_fn ? "$encoded_fn" : "$fn"), "\n");
       print_ddebug("type: ttf\n");
@@ -1323,8 +1313,7 @@ sub read_font_database {
       # cp932 for win32 console
       my $encoded_fn;
       if (win32()) {
-        $encoded_fn = Encode::decode('utf-8', $fn);
-        $encoded_fn = Encode::encode('cp932', $encoded_fn);
+        $encoded_fn = encode_utftocp($fn);
       }
       print_ddebug("filename: ", ($encoded_fn ? "$encoded_fn" : "$fn"), "\n");
       print_ddebug("type: ttc\n");
@@ -1338,8 +1327,7 @@ sub read_font_database {
       # cp932 for win32 console
       my $encoded_fn;
       if (win32()) {
-        $encoded_fn = Encode::decode('utf-8', $fn);
-        $encoded_fn = Encode::encode('cp932', $encoded_fn);
+        $encoded_fn = encode_utftocp($fn);
       }
       print_ddebug("filename: ", ($encoded_fn ? "$encoded_fn" : "$fn"), "\n");
       if ($fn =~ m/\.otf$/i) {
@@ -1436,6 +1424,20 @@ sub find_gs_resource {
     }
   }
   return $foundres;
+}
+
+sub encode_utftocp {
+  my ($foo) = @_;
+  $foo = Encode::decode('utf-8', $foo);
+  $foo = Encode::encode('cp932', $foo);
+  return $foo;
+}
+
+sub encode_cptoutf {
+  my ($foo) = @_;
+  $foo = Encode::decode('cp932', $foo);
+  $foo = Encode::encode('utf-8', $foo);
+  return $foo;
 }
 
 sub version {

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -3619,6 +3619,77 @@ Provides(90): STHeiti-Regular
 Provides(90): STHeiti-Light
 TTFname: ukai.ttf
 
+# WenQuanYi (free)
+
+# GB
+Name: WenQuanYiMicroHei
+Class: GB
+TTCname(10): wqy-microhei.ttc(0)
+# CNS
+Name: WenQuanYiMicroHei-Adobe-CNS1
+Class: CNS
+TTCname(10): wqy-microhei.ttc(0)
+
+# GB
+Name: WenQuanYiMicroHeiMono
+Class: GB
+TTCname(10): wqy-microhei.ttc(1)
+# CNS
+Name: WenQuanYiMicroHeiMono-Adobe-CNS1
+Class: CNS
+TTCname(10): wqy-microhei.ttc(1)
+
+# GB
+Name: WenQuanYiZenHei
+Class: GB
+TTCname(10): wqy-zenhei.ttc(0)
+TTFname(20): wqy-zenhei.ttf
+# CNS
+Name: WenQuanYiZenHei-Adobe-CNS1
+Class: CNS
+TTCname(10): wqy-zenhei.ttc(0)
+TTFname(20): wqy-zenhei.ttf
+
+# GB
+Name: WenQuanYiZenHeiMono
+Class: GB
+TTCname(10): wqy-zenhei.ttc(1)
+# CNS:
+Name: WenQuanYiZenHeiMono-Adobe-CNS1
+Class: CNS
+TTCname(10): wqy-zenhei.ttc(1)
+
+# GB
+Name: WenQuanYiZenHeiSharp
+Class: GB
+TTCname(10): wqy-zenhei.ttc(2)
+# CNS
+Name: WenQuanYiZenHeiSharp-Adobe-CNS1
+Class: CNS
+TTCname(10): wqy-zenhei.ttc(2)
+
+# cwTeX (free)
+
+Name: cwTeXMing
+Class: CNS
+TTFname: cwming.ttf
+
+Name: cwTeXHeiBold
+Class: CNS
+TTFname: cwheib.ttf
+
+Name: cwTeXKai
+Class: CNS
+TTFname: cwkai.ttf
+
+Name: cwTeXYen
+Class: CNS
+TTFname: cwyen.ttf
+
+Name: cwTeXFangSong
+Class: CNS
+TTFname: cwfs.ttf
+
 #
 # KOREAN FONTS
 #
@@ -3855,6 +3926,34 @@ Name: NanumPen
 Class: Korea
 TTFname(10): NanumPen.ttf
 TTCname(20): NanumScript.ttc(1)
+
+# Design font by Ho-Seok Ee, aka. "ALee's font" (free)
+
+Name: Bandal
+Class: Korea
+TTFname: Bandal.ttf
+
+Name: Bangwool
+Class: Korea
+TTFname: Bangwool.ttf
+
+Name: Eunjin
+Class: Korea
+TTFname: Eunjin.ttf
+
+Name: EunjinNakseo
+Class: Korea
+TTFname: EunjinNakseo.ttf
+
+Name: Guseul
+Class: Korea
+TTFname: Guseul.ttf
+
+# Woowa Brothers (free)
+
+Name: BMHANNA
+Class: Korea
+TTFname: BM-HANNA.ttf
 
 # Hancom HCR (free)
 # note that all fonts have narrow metrics

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -500,12 +500,8 @@ sub do_otf_fonts {
     if $opt_texmflink;
   for my $k (keys %fontdb) {
     if ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'OTF') {
-      if ($opt_akotfps) {
-        add_akotfps_data($k);
-      } else {
-        generate_font_snippet($fontdest,
-          $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
-      }
+      generate_font_snippet($fontdest,
+        $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
       link_font($fontdb{$k}{'target'}, $ciddest, $k);
       link_font($fontdb{$k}{'target'}, "$opt_texmflink/$otf_pathpart", "$fontdb{$k}{'origname'}.otf")
         if $opt_texmflink;
@@ -516,6 +512,10 @@ sub do_otf_fonts {
 sub generate_font_snippet {
   my ($fd, $n, $c, $f) = @_;
   return if $dry_run;
+  if ($opt_akotfps) {
+    add_akotfps_data($n);
+    return;
+  }
   for my $enc (@{$encode_list{$c}}) {
     if ($opt_remove) {
       unlink "$fd/$n-$enc" if (-f "$fd/$n-$enc");
@@ -638,23 +638,15 @@ sub do_nonotf_fonts {
     if $opt_texmflink;
   for my $k (keys %fontdb) {
     if ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'TTF') {
-      if ($opt_akotfps) {
-        add_akotfps_data($k);
-      } else {
-        generate_font_snippet($fontdest,
-          $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
-      }
+      generate_font_snippet($fontdest,
+        $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
       $outp .= generate_cidfmap_entry($k, $fontdb{$k}{'class'}, $fontdb{$k}{'ttfname'}, $fontdb{$k}{'subfont'});
       link_font($fontdb{$k}{'target'}, $cidfsubst, $fontdb{$k}{'ttfname'});
       link_font($fontdb{$k}{'target'}, "$opt_texmflink/$ttf_pathpart", $fontdb{$k}{'ttfname'})
         if $opt_texmflink;
     } elsif ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'TTC') {
-      if ($opt_akotfps) {
-        add_akotfps_data($k);
-      } else {
-        generate_font_snippet($fontdest,
-          $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
-      }
+      generate_font_snippet($fontdest,
+        $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
       $outp .= generate_cidfmap_entry($k, $fontdb{$k}{'class'}, $fontdb{$k}{'ttcname'}, $fontdb{$k}{'subfont'});
       link_font($fontdb{$k}{'target'}, $cidfsubst, $fontdb{$k}{'ttcname'});
       link_font($fontdb{$k}{'target'}, "$opt_texmflink/$ttf_pathpart", $fontdb{$k}{'ttcname'})
@@ -662,12 +654,8 @@ sub do_nonotf_fonts {
     } elsif ($fontdb{$k}{'available'} && $fontdb{$k}{'type'} eq 'OTC') {
     # currently ghostscript does not have OTC support; not creating gs resource
     print_ddebug("gs does not support OTC, not creating gs resource for $k\n");
-    # if ($opt_akotfps) {
-    #   add_akotfps_data($k);
-    # } else {
-    #   generate_font_snippet($fontdest,
-    #     $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
-    # }
+    # generate_font_snippet($fontdest,
+    #  $k, $fontdb{$k}{'class'}, $fontdb{$k}{'target'});
     # $outp .= generate_cidfmap_entry($k, $fontdb{$k}{'class'}, $fontdb{$k}{'otcname'}, $fontdb{$k}{'subfont'});
     # link_font($fontdb{$k}{'target'}, $cidfsubst, $fontdb{$k}{'otcname'});
       link_font($fontdb{$k}{'target'}, "$opt_texmflink/$otf_pathpart", $fontdb{$k}{'otcname'})
@@ -736,11 +724,7 @@ sub do_aliases {
     }
     # we also need to create font snippets in Font (or add configuration)
     # for the aliases!
-    if ($opt_akotfps) {
-      add_akotfps_data($al);
-    } else {
-      generate_font_snippet($fontdest, $al, $class, $target);
-    }
+    generate_font_snippet($fontdest, $al, $class, $target);
     if ($class eq 'Japan') {
       push @jal, "/$al /$target ;";
     } elsif ($class eq 'Korea') {

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -429,6 +429,13 @@ sub main {
     }
   }
   exit(0) if ($opt_listfonts || $opt_listaliases || $opt_listallaliases);
+  # if $opt_machine is still alive after the above exit(0), it's useless
+  if ($opt_machine) {
+    print_error("Option --machine-readable should be used with at least one of the followings:\n");
+    print_error("  --list-aliases, --list-all-aliases, --list-fonts, --info\n");
+    print_error("terminating.\n");
+    exit(1);
+  }
 
   if (! $opt_output) {
     print_info("searching for GhostScript resource\n");
@@ -1509,7 +1516,6 @@ sub Usage {
                          DIR/$akotfps_pathpart
                       which is used by ps2otfps (developed by Akira Kakuto),
                       instead of generating snippets
---machine-readable    output of --list-aliases is machine readable
 --force               do not bail out if linked fonts already exist
 -q, --quiet           be less verbose
 -d, --debug           output debug information, can be given multiple times
@@ -1531,6 +1537,7 @@ sub Usage {
                       present files
 --list-fonts          lists the fonts found on the system
 --info                combines the above two information
+--machine-readable    output of --list-aliases is machine readable
 ";
 
   my $shortdesc = "

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -820,7 +820,7 @@ sub maybe_symlink {
     $targetname =~ s!/!\\!g;
     if ($opt_winbatch) {
       # re-encoding of $winbatch_content is done by write_winbatch()
-      $winbatch_content .= "if not exist \"$targetname\" mklink /h \"$targetname\" \"$realname\"\n";
+      $winbatch_content .= "if not exist \"$targetname\" mklink \"$targetname\" \"$realname\"\n";
     } else {
       # should be encoded in cp932 for win32 console
       $realname = encode_utftocp($realname);
@@ -1363,8 +1363,9 @@ sub find_gs_resource {
     if ( -d "$foo/tlpkg/tlgs" ) {
       # should be texlive with tlgs
       $foundres = "$foo/tlpkg/tlgs/Resource";
-      # TODO: for TL2016, tlgs binary has built-in Resource,
-      # so the following test should fail!
+      # for TL2016, tlgs binary has built-in Resource,
+      # so we cannot set up CJK fonts correctly.
+      # the following test forces to exit in such case
       if ( ! -d $foundres ) {
         print_error("No Resource directory available for tlgs,\n");
         print_error("we cannot support such gs, sorry.\n");
@@ -1381,7 +1382,6 @@ sub find_gs_resource {
     }
   } else {
     # we assume that gs is in the path
-    # on Windows we probably have to try something else
     chomp( my $gsver = `gs --version 2>$nul` );
     if ($?) {
       print_error("Cannot get gs version ...\n");

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -41,7 +41,12 @@ if (win32()) {
   #   * input/output on console
   #   * batch file output
   # routines. make sure all of these should be restricted to win32 mode!
-  # TODO: what to do with $opt_fontdef, @opt_aliases and $opt_filelist ?
+  # TODO: what to do with $opt_fontdef, @opt_aliases and $opt_filelist,
+  #       with regard to encodings?
+  # TODO: running with --link-texmf option for multiple times is harmful,
+  #       because kpathsea catches texmflocal links and abs_path misunderstand
+  #       it as an actual file; currently the users have to run with --remove
+  #       first, before re-running with --link-texmf.
   use utf8;
   use Encode;
   # some perl functions (symlink, -l test) does not work

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1374,11 +1374,10 @@ sub find_gs_resource {
     chomp( my $foo = `kpsewhich -var-value=SELFAUTOPARENT`);
     if ( -d "$foo/tlpkg/tlgs" ) {
       # should be texlive with tlgs
-      if ( -d "$foo/tlpkg/tlgs/Resource" ) {
-        $foundres = "$foo/tlpkg/tlgs/Resource";
-      } else {
-        # TODO: for TL2016, tlgs binary has built-in Resource,
-        # so no Resource directory is available!
+      $foundres = "$foo/tlpkg/tlgs/Resource";
+      # TODO: for TL2016, tlgs binary has built-in Resource,
+      # so the following test should fail!
+      if ( ! -d $foundres ) {
         print_error("No Resource directory available for tlgs,\n");
         print_error("we cannot support such gs, sorry.\n");
         $foundres = '';

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -295,9 +295,9 @@ if (! GetOptions(
         "n|dry-run"   => \$dry_run,
         "q|quiet"     => \$opt_quiet,
         "d|debug+"    => \$opt_debug,
-        "v|version"   => sub { print &version(); exit(0); }, ) ) {
         "h|help"      => \$opt_help,
         "markdown"    => \$opt_markdown,
+        "v|version"   => sub { print &version(); exit(0); }, ) ) {
   die "Try \"$0 --help\" for more information.\n";
 }
 
@@ -1590,8 +1590,12 @@ to load the cidfmap.local and cidfmap.aliases.
 Search is done using the kpathsea library, in particular using kpsewhich
 program. By default the following directories are searched:
   - all TEXMF trees
-  - `/Library/Fonts`, `/Library/Fonts/Microsoft`, `/System/Library/Fonts`, 
-    `/Network/Library/Fonts`, and `~/Library/Fonts` (all if available)
+  - `/Library/Fonts`, `/Library/Fonts/Microsoft`, `/System/Library/Fonts`,
+    `/System/Library/Assets`, `/Network/Library/Fonts`,
+    `~/Library/Fonts` and `/usr/share/fonts` (all if available)
+  - `/Applications/Microsoft Word.app/Contents/Resources/{Fonts,DFonts}`,
+    `/Applications/Microsoft Excel.app/Contents/Resources/{Fonts,DFonts}`,
+    `/Applications/Microsoft PowerPoint.app/Contents/Resources/{Fonts,DFonts}`
   - `c:/windows/fonts` (on Windows)
   - the directories in `OSFONTDIR` environment variable
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -3810,6 +3810,10 @@ Name: MalgunGothicBold
 Class: Korea
 TTFname: malgunbd.ttf
 
+Name: MalgunGothic-Semilight
+Class: Korea
+TTFname: malgunsl.ttf
+
 # simplified chinese
 
 Name: SimHei
@@ -3844,11 +3848,50 @@ TTFname(20): simfang.ttf
 
 Name: MicrosoftYaHei
 Class: GB
-TTFname: msyh.ttf
+TTFname(20): msyh.ttf
+TTCname(30): msyh.ttc(0)
 
 Name: MicrosoftYaHei-Bold
 Class: GB
-TTFname: msyhbd.ttf
+TTFname(20): msyhbd.ttf
+TTCname(30): msyhbd.ttc(0)
+
+Name: MicrosoftYaHeiLight
+Class: GB
+TTFname(20): msyhl.ttf
+TTCname(30): msyhl.ttc(0)
+
+Name: DengXian-Regular
+Class: GB
+TTFname: Deng.ttf
+
+Name: DengXian-Bold
+Class: GB
+TTFname: Dengb.ttf
+
+Name: DengXian-Light
+Class: GB
+TTFname: Dengl.ttf
+
+Name: STZhongsong
+Class: GB
+TTFname: STZHONGS.ttf
+
+Name: STXinwei
+Class: GB
+TTFname: STXINWEI.ttf
+
+Name: STXingkai
+Class: GB
+TTFname: STXINGKA.ttf
+
+Name: STLiti
+Class: GB
+TTFname: STLITI.ttf
+
+Name: STHupo
+Class: GB
+TTFname: STHUPO.ttf
 
 # traditional chinese
 
@@ -3872,11 +3915,19 @@ TTFname: kaiu.ttf
 
 Name: MicrosoftJhengHeiRegular
 Class: CNS
-TTFname: msjh.ttf
+TTFname(40): MSJH.ttf
+TTFname(20): msjh.ttf
+TTCname(30): msjh.ttc(0)
 
 Name: MicrosoftJhengHeiBold
 Class: CNS
-TTFname: msjhbd.ttf
+TTFname(40): MSJHBD.ttf
+TTFname(20): msjhbd.ttf
+TTCname(30): msjhbd.ttc(0)
+
+Name: MicrosoftJhengHeiLight
+Class: CNS
+TTCname(30): msjhl.ttc(0)
 
 # japanese
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -502,7 +502,7 @@ sub update_master_cidfmap {
       } else {
         return if $dry_run;
         open(FOO, ">", $cidfmap_master) ||
-          die ("Cannot clean up $cidfmap_master: $!");
+          die ("Cannot open $cidfmap_master for appending: $!");
         print FOO $newmaster;
         print FOO "($add) .runlibfile\n";
         close(FOO);

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -951,7 +951,7 @@ sub check_for_files {
       # macosx specific; the path contains white space, so hack required
       for my $d (qw!/Applications/Microsoft__Word.app /Applications/Microsoft__Excel.app /Applications/Microsoft__PowerPoint.app!) {
         my $sd = $d;
-        $sd =~ s/_/ /;
+        $sd =~ s/__/ /;
         push @extradirs, "$sd/Contents/Resources/Fonts/" if (-d "$sd/Contents/Resources/Fonts");
         push @extradirs, "$sd/Contents/Resources/DFonts/" if (-d "$sd/Contents/Resources/DFonts");
       }


### PR DESCRIPTION
texjporg に branch を作り直したので、pull request も新しくします。

> `maybe_symlink` 何回もopen/closeすることはよくないです。できればすべてのラインを集めて、最後に全部あわせて書き出す

を直してみました。下の comments は #21 からの copy をまとめたものです。

----

cjk-gs-integrate が Win32 でも動けばいいと思って書いてみたコードです。

- TeX Live win32 の tlgs はまだサポートしていません。standalone の gswin32c の場合で動作するようにしています。
- Win32 では perl の symlink function がサポートされていません。そこで、代わりに makefontlinks.bat を作るようにしました。cjk-gs-integrate を実行したあとで、この batch file を cmd.exe で実行すると symlink が作れます。
- `--otfps` オプションを付けると、snippet をたくさん作る代わりに、角藤さんの ps2otfps というプログラム（dvips で作った PS を自動で編集して、Resource/Font にたくさん snippet を作らなくても CJK フォントを使えるようにする）の configuration file である psnames-for-otf を作ります。

【補足】ps2otfps の C program source は https://github.com/aminophen/ps2otfps です。TeX Live にはなく、W32TeX にだけ入っています。

- http://oku.edu.mie-u.ac.jp/tex/mod/forum/discuss.php?d=1110
- http://oku.edu.mie-u.ac.jp/tex/mod/forum/discuss.php?d=1659

MSVC (win32) だけでなく GCC (unix) でも make できます。

----

TODO 1: Windows では本当のフォントファイルと symlink などの区別がつかず、link の行き先を読めないので、abs_path のような処理が正しく機能していないっぽい。

TODO 2: TeX Live win32 の tlgs に対応していない。devel ML に流しましたが、gs の Resource directory が無いです。だから、snippets の output directory を決定できません。