### PR TITLE
Add AI0 snippet

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -728,7 +728,7 @@ sub do_aliases {
   #
   $outp .= "\n\n% Aliases\n";
   #
-  my (@jal, @kal, @tal, @sal);
+  my (@jal, @kal, @tal, @sal, @ai0al);
   #
   for my $al (sort keys %aliases) {
     my $target;
@@ -767,6 +767,8 @@ sub do_aliases {
       push @sal, "/$al /$target ;";
     } elsif ($class eq 'CNS') {
       push @tal, "/$al /$target ;";
+    } elsif ($class eq 'AI0') {
+      push @ai0al, "/$al /$target ;";
     } else {
       print STDERR "unknown class $class for $al\n";
     }
@@ -780,6 +782,7 @@ sub do_aliases {
   $outp .= "\n% Korean fonts\n" . join("\n", @kal) . "\n" if @kal;
   $outp .= "\n% Traditional Chinese fonts\n" . join("\n", @tal) . "\n" if @tal;
   $outp .= "\n% Simplified Chinese fonts\n" . join("\n", @sal) . "\n" if @sal;
+  $outp .= "\n% Adobe-Identity-0 fonts\n" . join("\n", @ai0al) . "\n" if @ai0al;
   #
   return if $dry_run;
   if ($outp && !$opt_remove) {
@@ -1256,7 +1259,7 @@ sub info_found_fonts {
 # dump aliases
 sub info_list_aliases {
   print "List of ", ($opt_listallaliases ? "all" : "available"), " aliases and their options (in decreasing priority):\n" unless $opt_machine;
-  my (@jal, @kal, @tal, @sal);
+  my (@jal, @kal, @tal, @sal, @ai0al);
   for my $al (sort keys %aliases) {
     my $cl;
     my @ks = sort { $a <=> $b} keys(%{$aliases{$al}});
@@ -1288,6 +1291,8 @@ sub info_list_aliases {
       push @sal, $foo;
     } elsif ($cl eq 'CNS') {
       push @tal, $foo;
+    } elsif ($cl eq 'AI0') {
+      push @ai0al, $foo;
     } else {
       print STDERR "unknown class $cl for $al\n";
     }
@@ -1297,11 +1302,13 @@ sub info_list_aliases {
     print @kal if @kal;
     print @sal if @sal;
     print @tal if @tal;
+    print @ai0al if @ai0al;
   } else {
     print "Aliases for Japanese fonts:\n", @jal, "\n" if @jal;
     print "Aliases for Korean fonts:\n", @kal, "\n" if @kal;
     print "Aliases for Simplified Chinese fonts:\n", @sal, "\n" if @sal;
     print "Aliases for Traditional Chinese fonts:\n", @tal, "\n" if @tal;
+    print "Aliases for Adobe-Identity-0 fonts:\n", @ai0al, "\n" if @ai0al;
   }
 }
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -950,6 +950,9 @@ sub generate_cidfmap_entry {
     $s .= "1) 5]";
   } elsif ($c eq "Korea") {
     $s .= "1) 2]";
+  } elsif ($c eq "AI0") {
+    print_warning("cannot use class AI0 for non-OTF $n, skipping.\n");
+    return '';
   } else {
     print_warning("unknown class $c for $n, skipping.\n");
     return '';

--- a/database/cjkgs-notosans.dat
+++ b/database/cjkgs-notosans.dat
@@ -1,182 +1,182 @@
 # NotoSans
 
 Name: NotoSansCJKjp-Thin
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Thin.otf
 OTCname(20): NotoSansCJK-Thin.ttc(0)
 
 Name: NotoSansCJKjp-Light
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Light.otf
 OTCname(20): NotoSansCJK-Light.ttc(0)
 
 Name: NotoSansCJKjp-DemiLight
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-DemiLight.otf
 OTCname(20): NotoSansCJK-DemiLight.ttc(0)
 
 Name: NotoSansCJKjp-Regular
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(0)
 
 Name: NotoSansCJKjp-Medium
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Medium.otf
 OTCname(20): NotoSansCJK-Medium.ttc(0)
 
 Name: NotoSansCJKjp-Bold
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(0)
 
 Name: NotoSansCJKjp-Black
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansCJKjp-Black.otf
 OTCname(20): NotoSansCJK-Black.ttc(0)
 
 Name: NotoSansCJKkr-Thin
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Thin.otf
 OTCname(20): NotoSansCJK-Thin.ttc(1)
 
 Name: NotoSansCJKkr-Light
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Light.otf
 OTCname(20): NotoSansCJK-Light.ttc(1)
 
 Name: NotoSansCJKkr-DemiLight
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-DemiLight.otf
 OTCname(20): NotoSansCJK-DemiLight.ttc(1)
 
 Name: NotoSansCJKkr-Regular
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(1)
 
 Name: NotoSansCJKkr-Medium
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Medium.otf
 OTCname(20): NotoSansCJK-Medium.ttc(1)
 
 Name: NotoSansCJKkr-Bold
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(1)
 
 Name: NotoSansCJKkr-Black
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansCJKkr-Black.otf
 OTCname(20): NotoSansCJK-Black.ttc(1)
 
 Name: NotoSansCJKsc-Thin
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Thin.otf
 OTCname(20): NotoSansCJK-Thin.ttc(2)
 
 Name: NotoSansCJKsc-Light
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Light.otf
 OTCname(20): NotoSansCJK-Light.ttc(2)
 
 Name: NotoSansCJKsc-DemiLight
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-DemiLight.otf
 OTCname(20): NotoSansCJK-DemiLight.ttc(2)
 
 Name: NotoSansCJKsc-Regular
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(2)
 
 Name: NotoSansCJKsc-Medium
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Medium.otf
 OTCname(20): NotoSansCJK-Medium.ttc(2)
 
 Name: NotoSansCJKsc-Bold
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(2)
 
 Name: NotoSansCJKsc-Black
-Class: GB
+Class: AI0
 OTFname(10): NotoSansCJKsc-Black.otf
 OTCname(20): NotoSansCJK-Black.ttc(2)
 
 Name: NotoSansCJKtc-Thin
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Thin.otf
 OTCname(20): NotoSansCJK-Thin.ttc(3)
 
 Name: NotoSansCJKtc-Light
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Light.otf
 OTCname(20): NotoSansCJK-Light.ttc(3)
 
 Name: NotoSansCJKtc-DemiLight
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-DemiLight.otf
 OTCname(20): NotoSansCJK-DemiLight.ttc(3)
 
 Name: NotoSansCJKtc-Regular
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(3)
 
 Name: NotoSansCJKtc-Medium
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Medium.otf
 OTCname(20): NotoSansCJK-Medium.ttc(3)
 
 Name: NotoSansCJKtc-Bold
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(3)
 
 Name: NotoSansCJKtc-Black
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansCJKtc-Black.otf
 OTCname(20): NotoSansCJK-Black.ttc(3)
 
 Name: NotoSansMonoCJKjp-Regular
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansMonoCJKjp-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(4)
 
 Name: NotoSansMonoCJKjp-Bold
-Class: Japan
+Class: AI0
 OTFname(10): NotoSansMonoCJKjp-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(4)
 
 Name: NotoSansMonoCJKkr-Regular
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansMonoCJKkr-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(5)
 
 Name: NotoSansMonoCJKkr-Bold
-Class: Korea
+Class: AI0
 OTFname(10): NotoSansMonoCJKkr-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(5)
 
 Name: NotoSansMonoCJKsc-Regular
-Class: GB
+Class: AI0
 OTFname(10): NotoSansMonoCJKsc-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(6)
 
 Name: NotoSansMonoCJKsc-Bold
-Class: GB
+Class: AI0
 OTFname(10): NotoSansMonoCJKsc-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(6)
 
 Name: NotoSansMonoCJKtc-Regular
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansMonoCJKtc-Regular.otf
 OTCname(20): NotoSansCJK-Regular.ttc(7)
 
 Name: NotoSansMonoCJKtc-Bold
-Class: CNS
+Class: AI0
 OTFname(10): NotoSansMonoCJKtc-Bold.otf
 OTCname(20): NotoSansCJK-Bold.ttc(7)
 

--- a/database/cjkgs-notoserif.dat
+++ b/database/cjkgs-notoserif.dat
@@ -1,141 +1,141 @@
 # NotoSerif
 
 Name: NotoSerifCJKjp-ExtraLight
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-ExtraLight.otf
 OTCname(20): NotoSerifCJK-ExtraLight.ttc(0)
 
 Name: NotoSerifCJKjp-Light
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-Light.otf
 OTCname(20): NotoSerifCJK-Light.ttc(0)
 
 Name: NotoSerifCJKjp-Regular
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-Regular.otf
 OTCname(20): NotoSerifCJK-Regular.ttc(0)
 
 Name: NotoSerifCJKjp-Medium
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-Medium.otf
 OTCname(20): NotoSerifCJK-Medium.ttc(0)
 
 Name: NotoSerifCJKjp-SemiBold
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-SemiBold.otf
 OTCname(20): NotoSerifCJK-SemiBold.ttc(0)
 
 Name: NotoSerifCJKjp-Bold
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-Bold.otf
 OTCname(20): NotoSerifCJK-Bold.ttc(0)
 
 Name: NotoSerifCJKjp-Black
-Class: Japan
+Class: AI0
 OTFname(10): NotoSerifCJKjp-Black.otf
 OTCname(20): NotoSerifCJK-Black.ttc(0)
 
 Name: NotoSerifCJKkr-ExtraLight
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-ExtraLight.otf
 OTCname(20): NotoSerifCJK-ExtraLight.ttc(1)
 
 Name: NotoSerifCJKkr-Light
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-Light.otf
 OTCname(20): NotoSerifCJK-Light.ttc(1)
 
 Name: NotoSerifCJKkr-Regular
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-Regular.otf
 OTCname(20): NotoSerifCJK-Regular.ttc(1)
 
 Name: NotoSerifCJKkr-Medium
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-Medium.otf
 OTCname(20): NotoSerifCJK-Medium.ttc(1)
 
 Name: NotoSerifCJKkr-SemiBold
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-SemiBold.otf
 OTCname(20): NotoSerifCJK-SemiBold.ttc(1)
 
 Name: NotoSerifCJKkr-Bold
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-Bold.otf
 OTCname(20): NotoSerifCJK-Bold.ttc(1)
 
 Name: NotoSerifCJKkr-Black
-Class: Korea
+Class: AI0
 OTFname(10): NotoSerifCJKkr-Black.otf
 OTCname(20): NotoSerifCJK-Black.ttc(1)
 
 Name: NotoSerifCJKsc-ExtraLight
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-ExtraLight.otf
 OTCname(20): NotoSerifCJK-ExtraLight.ttc(2)
 
 Name: NotoSerifCJKsc-Light
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-Light.otf
 OTCname(20): NotoSerifCJK-Light.ttc(2)
 
 Name: NotoSerifCJKsc-Regular
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-Regular.otf
 OTCname(20): NotoSerifCJK-Regular.ttc(2)
 
 Name: NotoSerifCJKsc-Medium
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-Medium.otf
 OTCname(20): NotoSerifCJK-Medium.ttc(2)
 
 Name: NotoSerifCJKsc-SemiBold
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-SemiBold.otf
 OTCname(20): NotoSerifCJK-SemiBold.ttc(2)
 
 Name: NotoSerifCJKsc-Bold
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-Bold.otf
 OTCname(20): NotoSerifCJK-Bold.ttc(2)
 
 Name: NotoSerifCJKsc-Black
-Class: GB
+Class: AI0
 OTFname(10): NotoSerifCJKsc-Black.otf
 OTCname(20): NotoSerifCJK-Black.ttc(2)
 
 Name: NotoSerifCJKtc-ExtraLight
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-ExtraLight.otf
 OTCname(20): NotoSerifCJK-ExtraLight.ttc(3)
 
 Name: NotoSerifCJKtc-Light
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-Light.otf
 OTCname(20): NotoSerifCJK-Light.ttc(3)
 
 Name: NotoSerifCJKtc-Regular
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-Regular.otf
 OTCname(20): NotoSerifCJK-Regular.ttc(3)
 
 Name: NotoSerifCJKtc-Medium
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-Medium.otf
 OTCname(20): NotoSerifCJK-Medium.ttc(3)
 
 Name: NotoSerifCJKtc-SemiBold
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-SemiBold.otf
 OTCname(20): NotoSerifCJK-SemiBold.ttc(3)
 
 Name: NotoSerifCJKtc-Bold
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-Bold.otf
 OTCname(20): NotoSerifCJK-Bold.ttc(3)
 
 Name: NotoSerifCJKtc-Black
-Class: CNS
+Class: AI0
 OTFname(10): NotoSerifCJKtc-Black.otf
 OTCname(20): NotoSerifCJK-Black.ttc(3)

--- a/database/cjkgs-sourcehansans.dat
+++ b/database/cjkgs-sourcehansans.dat
@@ -1,182 +1,182 @@
 # SourceHanSans
 
 Name: SourceHanSans-ExtraLight
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(0)
 
 Name: SourceHanSans-Light
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(0)
 
 Name: SourceHanSans-Normal
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(0)
 
 Name: SourceHanSans-Regular
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(0)
 
 Name: SourceHanSans-Medium
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(0)
 
 Name: SourceHanSans-Bold
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(0)
 
 Name: SourceHanSans-Heavy
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSans-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(0)
 
 Name: SourceHanSansK-ExtraLight
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(1)
 
 Name: SourceHanSansK-Light
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(1)
 
 Name: SourceHanSansK-Normal
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(1)
 
 Name: SourceHanSansK-Regular
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(1)
 
 Name: SourceHanSansK-Medium
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(1)
 
 Name: SourceHanSansK-Bold
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(1)
 
 Name: SourceHanSansK-Heavy
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansK-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(1)
 
 Name: SourceHanSansSC-ExtraLight
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(2)
 
 Name: SourceHanSansSC-Light
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(2)
 
 Name: SourceHanSansSC-Normal
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(2)
 
 Name: SourceHanSansSC-Regular
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(2)
 
 Name: SourceHanSansSC-Medium
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(2)
 
 Name: SourceHanSansSC-Bold
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(2)
 
 Name: SourceHanSansSC-Heavy
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansSC-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(2)
 
 Name: SourceHanSansTC-ExtraLight
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(3)
 
 Name: SourceHanSansTC-Light
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(3)
 
 Name: SourceHanSansTC-Normal
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(3)
 
 Name: SourceHanSansTC-Regular
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(3)
 
 Name: SourceHanSansTC-Medium
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(3)
 
 Name: SourceHanSansTC-Bold
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(3)
 
 Name: SourceHanSansTC-Heavy
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansTC-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(3)
 
 Name: SourceHanSansHW-Regular
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSansHW-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(4)
 
 Name: SourceHanSansHW-Bold
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSansHW-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(4)
 
 Name: SourceHanSansHWK-Regular
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansHWK-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(5)
 
 Name: SourceHanSansHWK-Bold
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSansHWK-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(5)
 
 Name: SourceHanSansHWSC-Regular
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansHWSC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(6)
 
 Name: SourceHanSansHWSC-Bold
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSansHWSC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(6)
 
 Name: SourceHanSansHWTC-Regular
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansHWTC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(7)
 
 Name: SourceHanSansHWTC-Bold
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSansHWTC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(7)
 

--- a/database/cjkgs-sourcehansans.dat
+++ b/database/cjkgs-sourcehansans.dat
@@ -2,181 +2,253 @@
 
 Name: SourceHanSans-ExtraLight
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(0)
 
 Name: SourceHanSans-Light
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(0)
 
 Name: SourceHanSans-Normal
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(0)
 
 Name: SourceHanSans-Regular
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(0)
 
 Name: SourceHanSans-Medium
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(0)
 
 Name: SourceHanSans-Bold
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(0)
 
 Name: SourceHanSans-Heavy
 Class: AI0
+CMap: UniSourceHanSansJP-UTF16-H
+CMap: UniSourceHanSansJP-UTF32-H
 OTFname(10): SourceHanSans-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(0)
 
 Name: SourceHanSansK-ExtraLight
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(1)
 
 Name: SourceHanSansK-Light
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(1)
 
 Name: SourceHanSansK-Normal
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(1)
 
 Name: SourceHanSansK-Regular
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(1)
 
 Name: SourceHanSansK-Medium
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(1)
 
 Name: SourceHanSansK-Bold
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(1)
 
 Name: SourceHanSansK-Heavy
 Class: AI0
+CMap: UniSourceHanSansKR-UTF16-H
+CMap: UniSourceHanSansKR-UTF32-H
 OTFname(10): SourceHanSansK-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(1)
 
 Name: SourceHanSansSC-ExtraLight
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(2)
 
 Name: SourceHanSansSC-Light
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(2)
 
 Name: SourceHanSansSC-Normal
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(2)
 
 Name: SourceHanSansSC-Regular
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(2)
 
 Name: SourceHanSansSC-Medium
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(2)
 
 Name: SourceHanSansSC-Bold
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(2)
 
 Name: SourceHanSansSC-Heavy
 Class: AI0
+CMap: UniSourceHanSansCN-UTF16-H
+CMap: UniSourceHanSansCN-UTF32-H
 OTFname(10): SourceHanSansSC-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(2)
 
 Name: SourceHanSansTC-ExtraLight
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-ExtraLight.otf
 OTCname(20): SourceHanSans-ExtraLight.ttc(3)
 
 Name: SourceHanSansTC-Light
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Light.otf
 OTCname(20): SourceHanSans-Light.ttc(3)
 
 Name: SourceHanSansTC-Normal
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Normal.otf
 OTCname(20): SourceHanSans-Normal.ttc(3)
 
 Name: SourceHanSansTC-Regular
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(3)
 
 Name: SourceHanSansTC-Medium
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Medium.otf
 OTCname(20): SourceHanSans-Medium.ttc(3)
 
 Name: SourceHanSansTC-Bold
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(3)
 
 Name: SourceHanSansTC-Heavy
 Class: AI0
+CMap: UniSourceHanSansTW-UTF16-H
+CMap: UniSourceHanSansTW-UTF32-H
 OTFname(10): SourceHanSansTC-Heavy.otf
 OTCname(20): SourceHanSans-Heavy.ttc(3)
 
 Name: SourceHanSansHW-Regular
 Class: AI0
+CMap: UniSourceHanSansHWJP-UTF16-H
+CMap: UniSourceHanSansHWJP-UTF32-H
 OTFname(10): SourceHanSansHW-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(4)
 
 Name: SourceHanSansHW-Bold
 Class: AI0
+CMap: UniSourceHanSansHWJP-UTF16-H
+CMap: UniSourceHanSansHWJP-UTF32-H
 OTFname(10): SourceHanSansHW-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(4)
 
 Name: SourceHanSansHWK-Regular
 Class: AI0
+CMap: UniSourceHanSansHWKR-UTF16-H
+CMap: UniSourceHanSansHWKR-UTF32-H
 OTFname(10): SourceHanSansHWK-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(5)
 
 Name: SourceHanSansHWK-Bold
 Class: AI0
+CMap: UniSourceHanSansHWKR-UTF16-H
+CMap: UniSourceHanSansHWKR-UTF32-H
 OTFname(10): SourceHanSansHWK-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(5)
 
 Name: SourceHanSansHWSC-Regular
 Class: AI0
+CMap: UniSourceHanSansHWCN-UTF16-H
+CMap: UniSourceHanSansHWCN-UTF32-H
 OTFname(10): SourceHanSansHWSC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(6)
 
 Name: SourceHanSansHWSC-Bold
 Class: AI0
+CMap: UniSourceHanSansHWCN-UTF16-H
+CMap: UniSourceHanSansHWCN-UTF32-H
 OTFname(10): SourceHanSansHWSC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(6)
 
 Name: SourceHanSansHWTC-Regular
 Class: AI0
+CMap: UniSourceHanSansHWTW-UTF16-H
+CMap: UniSourceHanSansHWTW-UTF32-H
 OTFname(10): SourceHanSansHWTC-Regular.otf
 OTCname(20): SourceHanSans-Regular.ttc(7)
 
 Name: SourceHanSansHWTC-Bold
 Class: AI0
+CMap: UniSourceHanSansHWTW-UTF16-H
+CMap: UniSourceHanSansHWTW-UTF32-H
 OTFname(10): SourceHanSansHWTC-Bold.otf
 OTCname(20): SourceHanSans-Bold.ttc(7)
 

--- a/database/cjkgs-sourcehanserif.dat
+++ b/database/cjkgs-sourcehanserif.dat
@@ -1,142 +1,142 @@
 # SourceHanSerif
 
 Name: SourceHanSerif-ExtraLight
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(0)
 
 Name: SourceHanSerif-Light
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(0)
 
 Name: SourceHanSerif-Regular
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(0)
 
 Name: SourceHanSerif-Medium
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(0)
 
 Name: SourceHanSerif-SemiBold
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(0)
 
 Name: SourceHanSerif-Bold
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(0)
 
 Name: SourceHanSerif-Heavy
-Class: Japan
+Class: AI0
 OTFname(10): SourceHanSerif-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(0)
 
 Name: SourceHanSerifK-ExtraLight
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(1)
 
 Name: SourceHanSerifK-Light
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(1)
 
 Name: SourceHanSerifK-Regular
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(1)
 
 Name: SourceHanSerifK-Medium
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(1)
 
 Name: SourceHanSerifK-SemiBold
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(1)
 
 Name: SourceHanSerifK-Bold
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(1)
 
 Name: SourceHanSerifK-Heavy
-Class: Korea
+Class: AI0
 OTFname(10): SourceHanSerifK-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(1)
 
 Name: SourceHanSerifSC-ExtraLight
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(2)
 
 Name: SourceHanSerifSC-Light
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(2)
 
 Name: SourceHanSerifSC-Regular
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(2)
 
 Name: SourceHanSerifSC-Medium
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(2)
 
 Name: SourceHanSerifSC-SemiBold
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(2)
 
 Name: SourceHanSerifSC-Bold
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(2)
 
 Name: SourceHanSerifSC-Heavy
-Class: GB
+Class: AI0
 OTFname(10): SourceHanSerifSC-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(2)
 
 Name: SourceHanSerifTC-ExtraLight
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(3)
 
 Name: SourceHanSerifTC-Light
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(3)
 
 Name: SourceHanSerifTC-Regular
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(3)
 
 Name: SourceHanSerifTC-Medium
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(3)
 
 Name: SourceHanSerifTC-SemiBold
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(3)
 
 Name: SourceHanSerifTC-Bold
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(3)
 
 Name: SourceHanSerifTC-Heavy
-Class: CNS
+Class: AI0
 OTFname(10): SourceHanSerifTC-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(3)
 

--- a/database/cjkgs-sourcehanserif.dat
+++ b/database/cjkgs-sourcehanserif.dat
@@ -2,141 +2,197 @@
 
 Name: SourceHanSerif-ExtraLight
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(0)
 
 Name: SourceHanSerif-Light
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(0)
 
 Name: SourceHanSerif-Regular
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(0)
 
 Name: SourceHanSerif-Medium
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(0)
 
 Name: SourceHanSerif-SemiBold
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(0)
 
 Name: SourceHanSerif-Bold
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(0)
 
 Name: SourceHanSerif-Heavy
 Class: AI0
+CMap: UniSourceHanSerifJP-UTF16-H
+CMap: UniSourceHanSerifJP-UTF32-H
 OTFname(10): SourceHanSerif-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(0)
 
 Name: SourceHanSerifK-ExtraLight
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(1)
 
 Name: SourceHanSerifK-Light
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(1)
 
 Name: SourceHanSerifK-Regular
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(1)
 
 Name: SourceHanSerifK-Medium
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(1)
 
 Name: SourceHanSerifK-SemiBold
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(1)
 
 Name: SourceHanSerifK-Bold
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(1)
 
 Name: SourceHanSerifK-Heavy
 Class: AI0
+CMap: UniSourceHanSerifKR-UTF16-H
+CMap: UniSourceHanSerifKR-UTF32-H
 OTFname(10): SourceHanSerifK-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(1)
 
 Name: SourceHanSerifSC-ExtraLight
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(2)
 
 Name: SourceHanSerifSC-Light
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(2)
 
 Name: SourceHanSerifSC-Regular
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(2)
 
 Name: SourceHanSerifSC-Medium
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(2)
 
 Name: SourceHanSerifSC-SemiBold
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(2)
 
 Name: SourceHanSerifSC-Bold
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(2)
 
 Name: SourceHanSerifSC-Heavy
 Class: AI0
+CMap: UniSourceHanSerifCN-UTF16-H
+CMap: UniSourceHanSerifCN-UTF32-H
 OTFname(10): SourceHanSerifSC-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(2)
 
 Name: SourceHanSerifTC-ExtraLight
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-ExtraLight.otf
 OTCname(20): SourceHanSerif-ExtraLight.ttc(3)
 
 Name: SourceHanSerifTC-Light
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-Light.otf
 OTCname(20): SourceHanSerif-Light.ttc(3)
 
 Name: SourceHanSerifTC-Regular
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-Regular.otf
 OTCname(20): SourceHanSerif-Regular.ttc(3)
 
 Name: SourceHanSerifTC-Medium
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-Medium.otf
 OTCname(20): SourceHanSerif-Medium.ttc(3)
 
 Name: SourceHanSerifTC-SemiBold
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-SemiBold.otf
 OTCname(20): SourceHanSerif-SemiBold.ttc(3)
 
 Name: SourceHanSerifTC-Bold
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-Bold.otf
 OTCname(20): SourceHanSerif-Bold.ttc(3)
 
 Name: SourceHanSerifTC-Heavy
 Class: AI0
+CMap: UniSourceHanSerifTW-UTF16-H
+CMap: UniSourceHanSerifTW-UTF32-H
 OTFname(10): SourceHanSerifTC-Heavy.otf
 OTCname(20): SourceHanSerif-Heavy.ttc(3)
 


### PR DESCRIPTION
まだ途中ですが AI0 フォントの snippet 処理を作ってみています。

#37 でご指摘させていただいた、
AI0 フォントに対して AJ1 用の CMap で snippet が作られてしまう件の対策が入っています。
さらに、AI0 フォントはフォント毎に CMap を指定できるようにした方がいいだろうと思い、
データベースで指定可能にするところまで実装してみました。

sourcehan の CMap （Adobe が配布しているファイル名）をデータベースに追加しており、
`--dump-data` で個別の CMap 名が読み込めていることを確認しています。

あとは実際に snippet を生成するところなどが残っています。