### PR TITLE
Add symlinking CMaps

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -917,6 +917,15 @@ sub generate_font_snippet {
   for my $enc (@{$encode_list{$c}}) {
     if ($opt_remove) {
       unlink "$fd/$n-$enc" if (-f "$fd/$n-$enc");
+      if(-l "$fd/../CMap/$enc") {
+        my $linkt = readlink("$fd/../CMap/$enc");
+        if($linkt) {
+          chomp(my $dest = `kpsewhich -format=cmap $enc`);
+          if($dest eq $linkt) {
+            unlink("$fd/../CMap/$enc");
+          }
+        }
+      }
       next;
     }
     open(FOO, ">$fd/$n-$enc") ||

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -934,6 +934,21 @@ pop
 %%EOF
 ";
     close(FOO);
+
+    if (! -d "$fd/../CMap") {
+      print_debug("Creating directory $fd/../CMap ...\n");
+      make_dir("$fd/../CMap", "cannot create CMap directory");
+    }
+    if (! -f "$fd/../CMap/$enc") {
+      print_debug("CMap $enc is not found in gs resource diretory\n");
+      chomp(my $dest = `kpsewhich -format=cmap $enc`);
+      if ($dest) {
+        print_debug("Symlinking CMap $dest ...\n");
+        link_font($dest, "$fd/../CMap", $enc);
+      } else {
+        print_debug("CMap $enc is not found by kpsewhich\n");
+      }
+    }
   }
 }
 


### PR DESCRIPTION
https://github.com/texjporg/jfontmaps/issues/27
で議論になった、 

> snippet で使っている CMap で gs が持っていないもの

のリンクを張る機能を作ってみました。

元々存在する CMap はそのままにして、存在しないもののみ kpsewhich で探してリンクを張ります。
`--remove` 指定時には、リンク先が kpsewhich の結果と同じ場合のみ削除します。