### PR TITLE
Remove cp932 dependency

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -724,8 +724,9 @@ sub do_nonotf_fonts {
       mkdir(encode('locale_fs', "$opt_output/Init")) ||
         die("Cannot create directory $opt_output/Init: $!");
     }
-    open(FOO, ">", encode('locale_fs',
-                          "$opt_output/$cidfmap_local_pathpart")) ||
+    # It seems that tlgs can handle UTF-8 TTF filename in cidfmap.local.
+    open(FOO, ">:encoding(UTF-8)",
+         encode('locale_fs', "$opt_output/$cidfmap_local_pathpart")) ||
       die("Cannot open $opt_output/$cidfmap_local_pathpart: $!");
     print FOO $outp;
     close(FOO);
@@ -814,7 +815,7 @@ sub do_aliases {
       mkdir(encode('locale_fs', "$opt_output/Init")) ||
         die("Cannot create directory $opt_output/Init: $!");
     }
-    open(FOO, ">",
+    open(FOO, ">:encoding(UTF-8)",
          encode('locale_fs', "$opt_output/$cidfmap_aliases_pathpart")) ||
       die("Cannot open $opt_output/$cidfmap_aliases_pathpart: $!");
     print FOO $outp;
@@ -912,7 +913,7 @@ sub update_master_cidfmap {
   print_info(sprintf("%s $add %s cidfmap file ...\n",
     ($opt_remove ? "removing" : "adding"), ($opt_remove ? "from" : "to")));
   if (-r encode('locale_fs', $cidfmap_master)) {
-    open(FOO, "<", encode('locale_fs', $cidfmap_master)) ||
+    open(FOO, "<:encoding(UTF-8)", encode('locale_fs', $cidfmap_master)) ||
       die("Cannot open $cidfmap_master for reading: $!");
     my $found = 0;
     my $found_tl = 0;
@@ -951,7 +952,7 @@ sub update_master_cidfmap {
     if ($opt_remove) {
       if ($found || $found_tl) {
         return if $dry_run;
-        open(FOO, ">", encode('locale_fs', $cidfmap_master)) ||
+        open(FOO, ">:encoding(UTF-8)", encode('locale_fs', $cidfmap_master)) ||
           die("Cannot clean up $cidfmap_master: $!");
         print FOO $newmaster;
         close FOO;
@@ -961,7 +962,7 @@ sub update_master_cidfmap {
         print_info("$add already loaded in $cidfmap_master, no changes\n");
       } else {
         return if $dry_run;
-        open(FOO, ">", encode('locale_fs', $cidfmap_master)) ||
+        open(FOO, ">:encoding(UTF-8)", encode('locale_fs', $cidfmap_master)) ||
           die("Cannot open $cidfmap_master for appending: $!");
         print FOO $newmaster;
         print FOO "($add) .runlibfile\n";
@@ -971,7 +972,7 @@ sub update_master_cidfmap {
   } else {
     return if $dry_run;
     return if $opt_remove;
-    open(FOO, ">", encode('locale_fs', $cidfmap_master)) ||
+    open(FOO, ">:encoding(UTF-8)", encode('locale_fs', $cidfmap_master)) ||
       die("Cannot open $cidfmap_master for writing: $!");
     print FOO "($add) .runlibfile\n";
     close(FOO);
@@ -1026,7 +1027,7 @@ sub generate_font_snippet {
           if (-f encode('locale_fs', "$fd/$n-$enc"));
       next;
     }
-    open(FOO, ">", encode('locale_fs', "$fd/$n-$enc")) ||
+    open(FOO, ">:encoding(UTF-8)", encode('locale_fs', "$fd/$n-$enc")) ||
       die("cannot open $fd/$n-$enc for writing: $!");
     print FOO "%!PS-Adobe-3.0 Resource-Font
 %%DocumentNeededResources: $enc (CMap)
@@ -1245,7 +1246,7 @@ sub write_akotfps_datafile {
   return if $dry_run;
   make_dir("$opt_akotfps/$akotfps_pathpart",
          "cannot create $akotfps_datafilename in it!");
-  open(FOO, ">",
+  open(FOO, ">:encoding(UTF-8)",
        encode('locale_fs',
               "$opt_akotfps/$akotfps_pathpart/$akotfps_datafilename")) ||
     die("cannot open $opt_akotfps/$akotfps_pathpart/$akotfps_datafilename for writing: $!");

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -37,6 +37,8 @@ use File::Basename;
 use File::Path qw(make_path);
 use Cwd 'abs_path';
 use strict;
+use utf8;
+use Encode;
 
 (my $prg = basename($0)) =~ s/\.pl$//;
 my $version = '$VER$';
@@ -51,8 +53,6 @@ if (win32()) {
   # routines. make sure all of these should be restricted to win32 mode!
   # TODO: what to do with $opt_fontdef, @opt_aliases and $opt_filelist,
   #       with regard to encodings?
-  use utf8;
-  use Encode;
   # some perl functions (symlink, -l test) does not work
   print_warning("Sorry, we have only partial support for Windows!\n");
 }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -31,12 +31,13 @@
 #
 # Note that symlink names should be consistent with ptex-fontmaps!
 
-$^W = 1;
 use Getopt::Long qw(:config no_autoabbrev ignore_case_always);
 use File::Basename;
 use File::Path qw(make_path);
 use Cwd 'abs_path';
 use strict;
+use warnings;
+no warnings qw(once);
 use utf8;
 use Encode;
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1863,7 +1863,7 @@ sub read_each_font_database {
 }
 
 sub dump_font_database {
-  open(FOO, ">$dump_datafile") ||
+  open(FOO, ">:encoding(UTF-8)", $dump_datafile) ||
     die("cannot open $dump_datafile for writing: $!");
   for my $k (sort keys %fontdb) {
     print FOO "Name: $fontdb{$k}{'origname'}\n";

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -40,6 +40,11 @@ use warnings;
 no warnings qw(once);
 use utf8;
 use Encode;
+use Encode::Locale;
+
+binmode (STDIN, ':encoding(console_in)');
+binmode (STDOUT, ':encoding(console_out)');
+binmode (STDERR, ':encoding(console_out)');
 
 (my $prg = basename($0)) =~ s/\.pl$//;
 my $version = '$VER$';

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -42,11 +42,13 @@ use utf8;
 use Encode;
 use Encode::Locale;
 
+Encode::Locale::decode_argv;
+
 binmode (STDIN, ':encoding(console_in)');
 binmode (STDOUT, ':encoding(console_out)');
 binmode (STDERR, ':encoding(console_out)');
 
-(my $prg = basename($0)) =~ s/\.pl$//;
+(my $prg = basename(decode('locale', $0))) =~ s/\.pl$//;
 my $version = '$VER$';
 
 if (win32()) {

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1434,7 +1434,7 @@ sub check_for_files {
   my %bntofn;
   for my $f (@foundfiles) {
     $f =~ s/[\r\n]+\z//; # perl's chomp() on git-bash cannot strip CR of CRLF ??
-    my $realf = abs_path($f);
+    my $realf = decode('locale_fs', abs_path(encode('locale_fs', $f)));
     if (!$realf) {
       print_warning("dead link or strange file found: $f - ignored!\n");
       next;

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -52,15 +52,6 @@ binmode (STDERR, ':encoding(console_out)');
 my $version = '$VER$';
 
 if (win32()) {
-  # conversion between internal (utf-8) and console (cp932):
-  # multibyte characters should be encoded in cp932 at least during
-  #   * kpathsea file search
-  #   * abs_path existence test
-  #   * input/output on console
-  #   * batch file output
-  # routines. make sure all of these should be restricted to win32 mode!
-  # TODO: what to do with $opt_fontdef, @opt_aliases and $opt_filelist,
-  #       with regard to encodings?
   # some perl functions (symlink, -l test) does not work
   print_warning("Sorry, we have only partial support for Windows!\n");
 }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -37,7 +37,6 @@ use File::Path qw(make_path);
 use Cwd 'abs_path';
 use strict;
 use warnings;
-no warnings qw(once);
 use utf8;
 use Encode;
 use Encode::Locale;
@@ -355,6 +354,7 @@ if (system("kpsewhich --version >$nul 2>&1 <$nul" ) != 0) {
 
 if ($opt_debug >= 2) {
   require Data::Dumper;
+  no warnings qw(once);
   $Data::Dumper::Indent = 1;
 }
 

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -410,7 +410,11 @@ if (defined($opt_texmflink)) {
   if ($opt_texmflink eq '') {
     # option was passed but didn't receive a value
     #  -> use TEXMFLOCAL
-    chomp($foo = `kpsewhich -var-value=TEXMFLOCAL`);
+    $foo = `kpsewhich -var-value=TEXMFLOCAL`;
+    # We assume that the output of kpsewhich is
+    # the same as perl's locale (or active code page).
+    decode('locale', $foo);
+    chomp($foo);
   } else {
     # option was passed with an argument
     #  -> use it
@@ -425,7 +429,11 @@ if (defined($opt_akotfps)) {
     if (defined($opt_texmflink)) {
       $foo = $opt_texmflink;
     } else {
-      chomp($foo = `kpsewhich -var-value=TEXMFLOCAL`);
+      $foo = `kpsewhich -var-value=TEXMFLOCAL`;
+      # We assume that the output of kpsewhich is
+      # the same as perl's locale (or active code page).
+      decode('locale', $foo);
+      chomp($foo);
     }
   } else {
     $foo = $opt_akotfps;
@@ -876,7 +884,11 @@ sub search_cmap {
   my ($cmap) = @_;
   # search CMap with kpsewhich and cache
   if (! exists $cmap_cache{$cmap}) {
-    chomp($cmap_cache{$cmap} = `kpsewhich -format=cmap $cmap`);
+    $cmap_cache{$cmap} = `kpsewhich -format=cmap $cmap`;
+    # We assume that the output of kpsewhich is
+    # the same as perl's locale (or active code page).
+    $cmap_cache{$cmap} = decode('locale', $cmap_cache{$cmap});
+    chomp($cmap_cache{$cmap});
     $cmap_cache{$cmap} =~ s/[\r\n]+\z//; # perl's chomp() on git-bash cannot strip CR of CRLF ??
   }
   return $cmap_cache{$cmap};
@@ -1913,7 +1925,11 @@ sub find_gs_resource {
   my $foundres = '';
   if (win32()) {
     # determine tlgs or native gs
-    chomp(my $foo = `kpsewhich -var-value=SELFAUTOPARENT`);
+    my $foo = `kpsewhich -var-value=SELFAUTOPARENT`;
+    # We assume that the output of kpsewhich is
+    # the same as perl's locale (or active code page).
+    decode('locale', $foo);
+    chomp($foo);
     if ( -d encode('locale_fs', "$foo/tlpkg/tlgs") ) {
       # should be texlive with tlgs
       print_debug("Assuming tlgs win32 ...\n");
@@ -2022,7 +2038,11 @@ sub kpse_miscfont {
   # first, prioritize GitHub repository diretory structure
   $foo = "database/$file" if (-f encode('locale_fs', "database/$file"));
   if ($foo eq "") {
-    chomp($foo = `kpsewhich -format=miscfont $file`);
+    $foo = `kpsewhich -format=miscfont $file`;
+    # We assume that the output of kpsewhich is
+    # the same as perl's locale (or active code page).
+    $foo = decode('locale', $foo);
+    chomp($foo);
   }
   return $foo;
 }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -1675,7 +1675,7 @@ sub read_font_database {
   # use "foo" as a substitute; otherwise, use built-in database
   if ($opt_fontdef) {
     my $foo = kpse_miscfont($opt_fontdef);
-    open(FDB, "<$foo") ||
+    open(FDB, "<:encoding(UTF-8)", $foo) ||
       die("Cannot find $opt_fontdef: $!");
     @dbl = <FDB>;
     close(FDB);
@@ -1689,7 +1689,7 @@ sub read_font_database {
   # overwrite existing one (that is, the addition wins)
   for (@opt_fontdef_add) {
     my $foo = kpse_miscfont($_);
-    open(FDB, "<$foo") ||
+    open(FDB, "<:encoding(UTF-8)", $foo) ||
       die("Cannot find $_: $!");
     @dbl = <FDB>;
     close(FDB);
@@ -1760,7 +1760,7 @@ sub read_each_font_database {
       next if (!$opt_cleanup);
       my @dbl;
       my $foo = kpse_miscfont($1);
-      if (!open(FDB, "<$foo")) {
+      if (!open(FDB, "<:encoding(UTF-8)", $foo)) {
         print_warning("Cannot find $1, skipping!\n");
         next;
       }
@@ -1773,7 +1773,7 @@ sub read_each_font_database {
     if ($l =~ m/^INCLUDE\s*(.*)$/) {
       my @dbl;
       my $foo = kpse_miscfont($1);
-      if (!open(FDB, "<$foo")) {
+      if (!open(FDB, "<:encoding(UTF-8)", $foo)) {
         print_warning("Cannot find $1, skipping!\n");
         next;
       }


### PR DESCRIPTION
https://github.com/texjporg/jfontmaps/issues/27#issuecomment-601068543
にて指摘させていただきましたが、Windows 環境では CP932 に依存した作りになっていて、他言語版 Windows の場合や、日本語版 Windows でも active codepage が CP65001 (UTF-8) になっている場合などが考慮されていないようです。
そこで、これらの環境でも非US-ASCIIのファイルを取り扱えるようにしてみました。また、 Windows か否かの判定を極力なくして共通の処理に変えたので、非 Windows 環境においても同様に非 US-ASCII のファイル名が使えるようになっています。

一部、絶対に US-ASCII だけだろうと思われる部分はそのままにしてあるところがあります。

なお、 Windows環境におけるシンボリックリンクなどの処理については
https://github.com/texjporg/jfontmaps/issues/27#issuecomment-601494166
の haranoaji-tlpost のような処理への改良をしておらず、従来どおりのままです。（本件だけでもそれなりの分量があってレビューいただくのも時間がかかると思いますし、変更等必要になったら手戻りがあるのも何なので、本件をマージしていただいたてから検討して別途 pull request にしようかと思っています。）