### PR TITLE
Support macOS 11.0 Big Sur

### DIFF
--- a/cjk-gs-integrate-macos.pl
+++ b/cjk-gs-integrate-macos.pl
@@ -48,15 +48,13 @@ if (macosx()) {
       $addname = "elcapitan";
     } elsif ($macos_ver_minor==12) {
       $addname = "sierra";
-    } elsif ($macos_ver_minor==13) {
-      $addname = "highsierra";
-    } elsif ($macos_ver_minor==14) {
-      $addname = "highsierra"; # mojave
-    } elsif ($macos_ver_minor==15) {
-      $addname = "highsierra"; # catalina -- at least nothing is wrong
-    } elsif ($macos_ver_minor>=16) {
-      print STDERR "Warning: macOS 10.$macos_ver_minor is untested.\n";
-      $addname = "highsierra"; # (the most recent one)
+    } elsif ($macos_ver_minor>=13) {
+      $addname = "highsierra"; # macOS 10.x was ended with x=15 (catalina)
+    } 
+  } elsif ($macos_ver_major==11) {
+    if ($macos_ver_minor==0) {
+      print STDERR "Warning: macOS 11.$macos_ver_minor is untested.\n";
+      $addname = "highsierra"; # big sur -- new major version
     }
   }
 }

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -385,7 +385,7 @@ if (macosx()) {
   $macos_ver_major =~ s/^(\d+)\.(\d+).*/$1/;
   my $macos_ver_minor = $macos_ver;
   $macos_ver_minor =~ s/^(\d+)\.(\d+).*/$2/;
-  if ($macos_ver_major==10 && $macos_ver_minor>=8) {
+  if ($macos_ver_major>=11 || ($macos_ver_major==10 && $macos_ver_minor>=8)) {
     if (!$opt_cleanup && !$opt_fontdef && !@opt_fontdef_add) { # if built-in only
       print_warning("Our built-in database does not support recent\n");
       print_warning("versions of Mac OS (10.8 Mountain Lion or later)!\n");


### PR DESCRIPTION
macOSのメジャーバージョンが10から11へ変更になったことに伴い、

- cjk-gs-integrate.pl
- cjk-gs-integrate-macos.pl

の内部的なバージョンチェッカが対応できなくなっていました。($macos_major_verが10固定のままでした)
この部分を変更し、macOS 11.0への条件分岐を追加し、当該バージョンへ対応しております。