### PR TITLE
Add win32 symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,6 @@ Usage
   -h, --help            this help
 `````
 
-#### Windows only options ####
-
-`````
-  --hardlink            create hardlinks instead of symlinks
-  --winbatch [FILE]     prepare a batch file for link generation, instead of
-                        generating links right away
-                        the batch file name defaults to makefontlinks.bat
-`````
-
 #### Command like options ####
 
 `````
@@ -216,8 +207,9 @@ Authors, Contributors, and Copyright
 ------------------------------------
 
 The script and its documentation was written by Norbert Preining, based
-on research and work by Yusuke Kuroki, Yusuke Terada, Bruno Voisin,
-Hironobu Yamashita, Munehiro Yamamoto and the TeX Q&A wiki page.
+on research and work by Masamichi Hosoda, Yusuke Kuroki, Yusuke Terada,
+Bruno Voisin, Hironobu Yamashita, Munehiro Yamamoto and the TeX Q&A wiki
+page.
 
 Maintained by Japanese TeX Development Community. For development, see
   https://github.com/texjporg/cjk-gs-support

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -6,6 +6,7 @@
 # Copyright 2016-2020 by Japanese TeX Development Community
 #
 # This work is based on research and work by (in alphabetical order)
+#   Masamichi Hosoda
 #   Yusuke Kuroki
 #   Yusuke Terada
 #   Bruno Voisin
@@ -2346,8 +2347,9 @@ requirements of `LL` and `RR` must be fulfilled:
 
   my $authors = "
 The script and its documentation was written by Norbert Preining, based
-on research and work by Yusuke Kuroki, Yusuke Terada, Bruno Voisin,
-Hironobu Yamashita, Munehiro Yamamoto and the TeX Q&A wiki page.
+on research and work by Masamichi Hosoda, Yusuke Kuroki, Yusuke Terada,
+Bruno Voisin, Hironobu Yamashita, Munehiro Yamamoto and the TeX Q&A wiki
+page.
 
 Maintained by Japanese TeX Development Community. For development, see
   https://github.com/texjporg/cjk-gs-support

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -60,6 +60,8 @@ if (win32()) {
 
   require Win32::API;
   Win32::API->import ();
+  require File::Compare;
+  File::Compare->import ();
 }
 
 # The followings are installed by ptex-fontmaps (texjporg):
@@ -1095,6 +1097,18 @@ sub link_font {
       if ($opt_force) {
         print_info("Removing $target due to --force!\n");
         $do_unlink = 1;
+      } elsif (win32()) {
+        my $result = compare (encode ('locale_fs', $f),
+                              encode ('locale_fs', $target));
+        if ($result == -1) {
+          print_error("file compare failed: ${f}, ${target}\n");
+          exit(1);
+        } elsif ($result) {
+          print_error("$target already existing and different content, exiting!\n");
+          exit(1);
+        }
+        print_debug("$target already existing but same content, skipping!\n");
+        return;
       } else {
         print_error("$target already existing, exiting!\n");
         exit(1);

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -445,12 +445,7 @@ if (defined($opt_winbatch)) {
   print_warning("ignoring --winbatch option due to being obsolete\n");
 }
 if ($opt_hardlink) {
-  if (win32()) {
-    $opt_hardlink = 1;
-  } else {
-    print_warning("ignoring --hardlink option due to non-Windows\n");
-    $opt_hardlink = 0;
-  }
+  print_warning("ignoring --hardlink option due to being obsolete\n");
 }
 
 if (defined($opt_dump_data)) {
@@ -2182,10 +2177,6 @@ sub Usage {
 -h, --help            this help
 ";
 
-  my $winonlyoptions = "
---hardlink            create hardlinks instead of symlinks
-";
-
   my $commandoptions = "
 --dump-data [FILE]    dump the set of font definitions which is currently
                       effective, where FILE (the dump output) defaults to
@@ -2358,8 +2349,6 @@ The contained font data is not copyrightable.
     print "\n$shortdesc\nUsage\n-----\n\n`````\n$usage\n`````\n\n";
     print "#### Options ####\n\n`````";
     print_for_out($options, "  ");
-    print "`````\n\n#### Windows only options ####\n\n`````";
-    print_for_out($winonlyoptions, "  ");
     print "`````\n\n#### Command like options ####\n\n`````";
     print_for_out($commandoptions, "  ");
     print "`````\n\nOperation\n---------\n$operation\n";
@@ -2375,10 +2364,6 @@ The contained font data is not copyrightable.
     print "\nUsage: $usage\n\n$headline\n$shortdesc";
     print "\nOptions:\n";
     print_for_out($options, "  ");
-    if (win32()) {
-      print "\nWindows only options:\n";
-      print_for_out($winonlyoptions, "  ");
-    }
     print "\nCommand like options:\n";
     print_for_out($commandoptions, "  ");
     print "\nOperation:\n";


### PR DESCRIPTION
Windows でシンボリックリンクできるようにしてみました。
それなりに大きな変更だと思いますし、これでよいかご意見など伺いたいため、Pull Request します。

非Windows環境の動作は変わっていないはずです。Cygwin環境の動作も変わっていません。

Windows 版 TeX Live 2020 に付属している perl での動作を確認しています。
まず、シンボリックリンクを試して、ダメならハードリンク、それもダメならコピーするようにしてあります。
（haranoaji-tlpost.pl の動作と同じです。）
コマンドラインオプション `--winbatch` および `--hardlink` は廃止にし、指定されていたら警告を出すようにしています。