### PR TITLE
macos 11.x workaround

### DIFF
--- a/cjk-gs-integrate-macos.pl
+++ b/cjk-gs-integrate-macos.pl
@@ -52,7 +52,7 @@ if (macosx()) {
       $addname = "highsierra"; # macOS 10.x was ended with x=15 (catalina)
     }
   } elsif ($macos_ver_major==11) {
-    if ($macos_ver_minor==0) {
+    if ($macos_ver_minor>=0) {
       print STDERR "Warning: macOS 11.$macos_ver_minor is untested.\n";
       $addname = "highsierra"; # big sur -- new major version
     }


### PR DESCRIPTION
#44 の関連PRとなります。

macos 11.0のみに対応となっていたものを、11.x (x >= 0) に対応するように修正いたしました。
現行のmacos 11.4にて、#44 のチェックと同じものを実行しています。結果、問題ないようです。

フォントデータベースの確認
```
$ cd /path/to/git-clone/cjk-gs-support
$ perl cjk-gs-integrate-macos.pl --strict-psname --dry-run
Warning: macOS 11.4 is untested.
cjk-gs-integrate: reading font database ...
cjk-gs-integrate: checking for files ...
cjk-gs-integrate: searching for Ghostscript resource
cjk-gs-integrate: output is going to /usr/local/share/ghostscript/9.54.0/Resource
cjk-gs-integrate: generating links and snippets for CID fonts ...
cjk-gs-integrate: generating links, snippets and cidfmap.local for non-CID fonts ...
cjk-gs-integrate: generating snippets and cidfmap.aliases for font aliases ...
cjk-gs-integrate: finished
```

リンク・ファイル一覧の確認
```
$ perl cjk-gs-integrate-macos.pl --link-texmf=aaa --output=bbb
$ ls -lR aaa bbb  > tmp.txt
```
[tmp.txt](https://github.com/texjporg/cjk-gs-support/files/6606255/tmp.txt)