### PR TITLE
Add Adobe-KR (AKR) support

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2703,6 +2703,9 @@ INCLUDE cjkgs-hancom.dat
 # HaranoAji
 # (already included in JAPANESE section)
 
+# IBM Plex
+# (already included in JAPANESE section)
+
 
 #
 # Microsoft Windows, Windows/Mac Office fonts

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -262,6 +262,23 @@ my %encode_list = (
     UniKS-UTF32-V
     UniKS-UTF8-H
     UniKS-UTF8-V
+    / ],
+  KR => [ qw/
+    Adobe-KR-0
+    Adobe-KR-1
+    Adobe-KR-2
+    Adobe-KR-3
+    Adobe-KR-4
+    Adobe-KR-5
+    Adobe-KR-6
+    Adobe-KR-7
+    Adobe-KR-8
+    Adobe-KR-9
+    Identity-H
+    Identity-V
+    UniAKR-UTF16-H
+    UniAKR-UTF32-H
+    UniAKR-UTF8-H
     / ] );
 
 #
@@ -725,7 +742,7 @@ sub do_aliases {
   #
   $outp .= "\n\n% Aliases\n";
   #
-  my (@jal, @kal, @tal, @sal, @ai0al);
+  my (@jal, @kal, @kral, @tal, @sal, @ai0al);
   #
   for my $al (sort keys %aliases) {
     my $target;
@@ -760,6 +777,8 @@ sub do_aliases {
       push @jal, "/$al /$target ;";
     } elsif ($class eq 'Korea') {
       push @kal, "/$al /$target ;";
+    } elsif ($class eq 'KR') {
+      push @kral, "/$al /$target ;";
     } elsif ($class eq 'GB') {
       push @sal, "/$al /$target ;";
     } elsif ($class eq 'CNS') {
@@ -778,7 +797,8 @@ sub do_aliases {
       if (! -r encode('locale_fs', "$ciddest/HeiseiKakuGo-W5"));
   #
   $outp .= "\n% Japanese fonts\n" . join("\n", @jal) . "\n" if @jal;
-  $outp .= "\n% Korean fonts\n" . join("\n", @kal) . "\n" if @kal;
+  $outp .= "\n% Korean (AK1) fonts\n" . join("\n", @kal) . "\n" if @kal;
+  $outp .= "\n% Korean (AKR) fonts\n" . join("\n", @kral) . "\n" if @kral;
   $outp .= "\n% Traditional Chinese fonts\n" . join("\n", @tal) . "\n" if @tal;
   $outp .= "\n% Simplified Chinese fonts\n" . join("\n", @sal) . "\n" if @sal;
   $outp .= "\n% Adobe-Identity-0 fonts\n" . join("\n", @ai0al) . "\n" if @ai0al;
@@ -974,6 +994,8 @@ sub generate_cidfmap_entry {
     $s .= "1) 5]";
   } elsif ($c eq "Korea") {
     $s .= "1) 2]";
+  } elsif ($c eq "KR") {
+    $s .= ") 9]";
   } elsif ($c eq "AI0") {
     print_warning("cannot use class AI0 for non-OTF $n, skipping.\n");
     return '';
@@ -1365,7 +1387,7 @@ sub info_found_fonts {
 # dump aliases
 sub info_list_aliases {
   print "List of ", ($opt_listallaliases ? "all" : "available"), " aliases and their options (in decreasing priority):\n" unless $opt_machine;
-  my (@jal, @kal, @tal, @sal, @ai0al);
+  my (@jal, @kal, @kral, @tal, @sal, @ai0al);
   for my $al (sort keys %aliases) {
     my $cl;
     my @ks = sort { $a <=> $b} keys(%{$aliases{$al}});
@@ -1389,6 +1411,8 @@ sub info_list_aliases {
       push @jal, $foo;
     } elsif ($cl eq 'Korea') {
       push @kal, $foo;
+    } elsif ($cl eq 'KR') {
+      push @kral, $foo;
     } elsif ($cl eq 'GB') {
       push @sal, $foo;
     } elsif ($cl eq 'CNS') {
@@ -1402,12 +1426,14 @@ sub info_list_aliases {
   if ($opt_machine) {
     print @jal if @jal;
     print @kal if @kal;
+    print @kral if @kral;
     print @sal if @sal;
     print @tal if @tal;
     print @ai0al if @ai0al;
   } else {
     print "Aliases for Japanese fonts:\n", @jal, "\n" if @jal;
-    print "Aliases for Korean fonts:\n", @kal, "\n" if @kal;
+    print "Aliases for Korean (AK1) fonts:\n", @kal, "\n" if @kal;
+    print "Aliases for Korean (AKR) fonts:\n", @kral, "\n" if @kral;
     print "Aliases for Simplified Chinese fonts:\n", @sal, "\n" if @sal;
     print "Aliases for Traditional Chinese fonts:\n", @tal, "\n" if @tal;
     print "Aliases for Adobe-Identity-0 fonts:\n", @ai0al, "\n" if @ai0al;

--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2613,7 +2613,7 @@ Class: CNS
 TTFname: cwfs.ttf
 
 #
-# KOREAN FONTS
+# KOREAN (AK1) FONTS
 #
 
 # Adobe -- Provides K30/80
@@ -2695,6 +2695,13 @@ TTFname: BM-HANNA.ttf
 
 # Hancom HCR (free)
 INCLUDE cjkgs-hancom.dat
+
+#
+# KOREAN (AKR) FONTS
+#
+
+# HaranoAji
+# (already included in JAPANESE section)
 
 
 #

--- a/database/cjkgs-haranoaji.dat
+++ b/database/cjkgs-haranoaji.dat
@@ -215,7 +215,7 @@ Name: HaranoAjiGothicTW-Heavy
 Class: CNS
 OTFname: HaranoAjiGothicTW-Heavy.otf
 
-### KOREAN ###
+### KOREAN (AK1) ###
 
 Name: HaranoAjiMinchoK1-ExtraLight
 Class: Korea
@@ -275,3 +275,61 @@ OTFname: HaranoAjiGothicK1-Bold.otf
 Name: HaranoAjiGothicK1-Heavy
 Class: Korea
 OTFname: HaranoAjiGothicK1-Heavy.otf
+
+### KOREAN (AKR) ###
+
+Name: HaranoAjiMinchoKR-ExtraLight
+Class: KR
+OTFname: HaranoAjiMinchoKR-ExtraLight.otf
+
+Name: HaranoAjiMinchoKR-Light
+Class: KR
+OTFname: HaranoAjiMinchoKR-Light.otf
+
+Name: HaranoAjiMinchoKR-Regular
+Class: KR
+OTFname: HaranoAjiMinchoKR-Regular.otf
+
+Name: HaranoAjiMinchoKR-Medium
+Class: KR
+OTFname: HaranoAjiMinchoKR-Medium.otf
+
+Name: HaranoAjiMinchoKR-SemiBold
+Class: KR
+OTFname: HaranoAjiMinchoKR-SemiBold.otf
+
+Name: HaranoAjiMinchoKR-Bold
+Class: KR
+OTFname: HaranoAjiMinchoKR-Bold.otf
+
+Name: HaranoAjiMinchoKR-Heavy
+Class: KR
+OTFname: HaranoAjiMinchoKR-Heavy.otf
+
+Name: HaranoAjiGothicKR-ExtraLight
+Class: KR
+OTFname: HaranoAjiGothicKR-ExtraLight.otf
+
+Name: HaranoAjiGothicKR-Light
+Class: KR
+OTFname: HaranoAjiGothicKR-Light.otf
+
+Name: HaranoAjiGothicKR-Normal
+Class: KR
+OTFname: HaranoAjiGothicKR-Normal.otf
+
+Name: HaranoAjiGothicKR-Regular
+Class: KR
+OTFname: HaranoAjiGothicKR-Regular.otf
+
+Name: HaranoAjiGothicKR-Medium
+Class: KR
+OTFname: HaranoAjiGothicKR-Medium.otf
+
+Name: HaranoAjiGothicKR-Bold
+Class: KR
+OTFname: HaranoAjiGothicKR-Bold.otf
+
+Name: HaranoAjiGothicKR-Heavy
+Class: KR
+OTFname: HaranoAjiGothicKR-Heavy.otf

--- a/database/cjkgs-ibm-plex.dat
+++ b/database/cjkgs-ibm-plex.dat
@@ -33,3 +33,37 @@ OTFname: IBMPlexSansJP-SemiBold.otf
 Name: IBMPlexSansJP-Bold
 Class: Japan
 OTFname: IBMPlexSansJP-Bold.otf
+
+### KOREAN (AKR) ###
+
+Name: IBMPlexSansKR-Thin
+Class: KR
+OTFname: IBMPlexSansKR-Thin.otf
+
+Name: IBMPlexSansKR-ExtraLight
+Class: KR
+OTFname: IBMPlexSansKR-ExtraLight.otf
+
+Name: IBMPlexSansKR-Light
+Class: KR
+OTFname: IBMPlexSansKR-Light.otf
+
+Name: IBMPlexSansKR-Regular
+Class: KR
+OTFname: IBMPlexSansKR-Regular.otf
+
+Name: IBMPlexSansKR-Text
+Class: KR
+OTFname: IBMPlexSansKR-Text.otf
+
+Name: IBMPlexSansKR-Medium
+Class: KR
+OTFname: IBMPlexSansKR-Medium.otf
+
+Name: IBMPlexSansKR-SemiBold
+Class: KR
+OTFname: IBMPlexSansKR-SemiBold.otf
+
+Name: IBMPlexSansKR-Bold
+Class: KR
+OTFname: IBMPlexSansKR-Bold.otf


### PR DESCRIPTION
Adobe-KR (AKR) の韓国語フォント対応を追加します。
あわせて、AKR である HaranoAji Fonts KR と IBM Plex Sans KR をデータベースに追加します。
機能追加になるのでレビューをお願いしたく pull request にしました。問題なさそうならマージします。

IBM Plex Sans JP は AJ1 フォントで、特に機能追加の必要が無かったため eef0c6fd4c2094933b5b6ba01c64e7da9f2266c2 でデータベースに追加済です。
IBM Plex Sans KR は既に対応している AK1 フォントではなくて未対応の AKR フォントだったため、本 pull request で AKR 対応を追加してから入れています。
原ノ味フォント韓国語版は AK1 の HaranoAji Fonts K1 は既に入っていますが、本 pull request で AKR の HaranoAji Fonts KR を追加しています。