### PR TITLE
cjk-gs-integrate.pl: use TEXMFROOT instead of SELFAUTOPARENT

### DIFF
--- a/cjk-gs-integrate.pl
+++ b/cjk-gs-integrate.pl
@@ -2021,7 +2021,7 @@ sub find_gs_resource {
   my $foundres = '';
   if (win32()) {
     # determine tlgs or native gs
-    my $foo = `kpsewhich -var-value=SELFAUTOPARENT`;
+    my $foo = `kpsewhich -var-value=TEXMFROOT`;
     # We assume that the output of kpsewhich is
     # the same as perl's locale (or active code page).
     decode('locale', $foo);


### PR DESCRIPTION
As discussed extensively in https://github.com/Homebrew/homebrew-core/pull/83738, using `SELFAUTOPARENT` to find the TexLive root may lead to brekage in distro TeXLive builds which do not use an architecture subdirectory within `bin`.  Using `TEXMFROOT` resolves this as it can be changed in `texmf.cnf` by the distro, where as `SELFAUTOPARENT` cannot be changed.  This should not cause any issues with the default TeXLive installation because the default value of `TEXMFROOT` is `SELFAUTOPARENT`.